### PR TITLE
github actions: Add publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      CRI_BIN: podman
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Login to quay.io
+        run:
+          ${CRI_BIN} login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+      - name: Build and push image
+        run: make build push


### PR DESCRIPTION
Add the publish workflow, in order to push the
checkup's image to `quay.io/kiagnose/kubevirt-dpdk-checkup:<tag>`.

