### PR TITLE
golangci-lint: Add config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,108 @@
+# golangci configuration
+
+linters-settings:
+  gofmt:
+    simplify: false
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  gci:
+    local-prefixes: github.com/kiagnose/kubevirt-dpdk-checkup
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+    settings:
+      hugeParam:
+        sizeThreshold: 1024
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/kiagnose/kubevirt-dpdk-checkup
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goheader
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+  # disabled beacuse of generics, tracker https://github.com/golangci/golangci-lint/issues/2649.
+  #  - rowserrcheck
+
+  # don't enable:
+  # - asciicheck
+  # - scopelint
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - maligned
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - revive
+  # - wsl

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GO_MOD_VERSION=$(shell hack/go-mod-version.sh)
 
 all: check build
 
-check: fmt check-uncommitted lint test/unit
+check: lint test/unit
 
 build:
 	$(CRI_BIN) run --rm \


### PR DESCRIPTION
This PR adds a config file that configures `make lint` to use the linters needed for this project