### PR TITLE
Makefile: Add cache to build, unit-test and lint targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 
 # Cache
 linter-cache
+go-cache

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
-#infra folders
+# Infra folders
 .github
+
+# Cache
+linter-cache

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ _output
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Cache
+linter-cache
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ _output
 
 # Cache
 linter-cache
-
+go-cache

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,10 @@ test/unit:
 .PHONY: test/unit
 
 lint:
+	mkdir -p $(CURDIR)/linter-cache
 	$(CRI_BIN) run --rm \
 	           --volume `pwd`:$(CURDIR):Z \
+	           --volume $(CURDIR)/linter-cache:/root/.cache:Z \
 	           --workdir $(CURDIR) \
 	            $(LINTER_IMAGE_NAME):$(LINTER_IMAGE_TAG) golangci-lint run --timeout 3m ./cmd/...
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,10 @@ all: check build
 check: fmt check-uncommitted lint test/unit
 
 build:
+	mkdir -p $(CURDIR)/go-cache
 	$(CRI_BIN) run --rm \
 	           --volume `pwd`:$(CURDIR):Z \
+	           --volume $(CURDIR)/go-cache:/root/.cache/go-build:Z \
 	           --workdir $(CURDIR) \
 	           -e GOOS=linux \
 	           -e GOARCH=amd64 \
@@ -33,8 +35,10 @@ push:
 .PHONY: push
 
 test/unit:
+	mkdir -p $(CURDIR)/go-cache
 	$(CRI_BIN) run --rm \
 	           --volume `pwd`:$(CURDIR):Z \
+	           --volume $(CURDIR)/go-cache:/root/.cache/go-build:Z \
 	           --workdir $(CURDIR) \
 	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go test -v ./cmd/...
 .PHONY: test/unit


### PR DESCRIPTION
Currently, it takes several minutes for the lint, unit-test and build targets to complete locally.
Add a cache directory for the lint target, and another one for the unit-test and build targets.
The addition of cache speeds up the build process.