### PR TITLE
tests: Fix linter problem

### DIFF
--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -49,7 +49,11 @@ var _ = Describe("Execute the checkup Job", func() {
 
 		DeferCleanup(func() {
 			backgroundPropagationPolicy := metav1.DeletePropagationBackground
-			err = virtClient.BatchV1().Jobs(testNamespace).Delete(context.Background(), testCheckupJobName, metav1.DeleteOptions{PropagationPolicy: &backgroundPropagationPolicy})
+			err = virtClient.BatchV1().Jobs(testNamespace).Delete(
+				context.Background(),
+				testCheckupJobName,
+				metav1.DeleteOptions{PropagationPolicy: &backgroundPropagationPolicy},
+			)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Currently, the linter is complaining that a line is too long. Break that function call to multiple lines.

Signed-off-by: Orel Misan <omisan@redhat.com>