### PR TITLE
config: Add east west params

### DIFF
--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -35,7 +35,7 @@ const (
 	DPDKNodeLabelSelectorParamName                      = "DPDKNodeLabelSelector"
 	TrafficGeneratorPacketsPerSecondInMillionsParamName = "trafficGeneratorPacketsPerSecondInMillions"
 	PortBandwidthGBParamName                            = "portBandwidthGB"
-	TrafficGeneratorMacAddressParamName                 = "trafficGeneratorMacAddress"
+	TrafficGeneratorEastMacAddressParamName             = "trafficGeneratorEastMacAddress"
 	DPDKMacAddressParamName                             = "DPDKMacAddress"
 	TestDurationParamName                               = "testDuration"
 )
@@ -43,7 +43,7 @@ const (
 const (
 	TrafficGeneratorPacketsPerSecondInMillionsDefault = 14
 	PortBandwidthGBDefault                            = 10
-	TrafficGeneratorMacAddressDefault                 = "50:00:00:00:00:01"
+	TrafficGeneratorEastMacAddressDefault             = "50:00:00:00:00:01"
 	DPDKMacAddressDefault                             = "60:00:00:00:00:01"
 	TestDurationDefault                               = 5 * time.Minute
 )
@@ -55,7 +55,7 @@ var (
 	ErrInvalidDPDKNodeLabelSelector                      = errors.New("invalid DPDK Node Label Selector")
 	ErrInvalidTrafficGeneratorPacketsPerSecondInMillions = errors.New("invalid Traffic Generator Packets Per Second In Millions")
 	ErrInvalidPortBandwidthGB                            = errors.New("invalid Port Bandwidth [GB]")
-	ErrInvalidTrafficGeneratorMacAddress                 = errors.New("invalid Traffic Generator MAC Address")
+	ErrInvalidTrafficGeneratorEastMacAddress             = errors.New("invalid Traffic Generator East MAC Address")
 	ErrInvalidDPDKMacAddress                             = errors.New("invalid DPDK MAC Address")
 	ErrInvalidTestDuration                               = errors.New("invalid Test Duration")
 )
@@ -69,13 +69,13 @@ type Config struct {
 	DPDKNodeLabelSelector                      string
 	TrafficGeneratorPacketsPerSecondInMillions int
 	PortBandwidthGB                            int
-	TrafficGeneratorMacAddress                 net.HardwareAddr
+	TrafficGeneratorEastMacAddress             net.HardwareAddr
 	DPDKMacAddress                             net.HardwareAddr
 	TestDuration                               time.Duration
 }
 
 func New(baseConfig kconfig.Config) (Config, error) {
-	trafficGeneratorMacAddressDefault, _ := net.ParseMAC(TrafficGeneratorMacAddressDefault)
+	trafficGeneratorEastMacAddressDefault, _ := net.ParseMAC(TrafficGeneratorEastMacAddressDefault)
 	dpdkMacAddressDefault, _ := net.ParseMAC(DPDKMacAddressDefault)
 	newConfig := Config{
 		PodName:                           baseConfig.PodName,
@@ -84,10 +84,10 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		TrafficGeneratorNodeLabelSelector: baseConfig.Params[TrafficGeneratorNodeLabelSelectorParamName],
 		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
 		TrafficGeneratorPacketsPerSecondInMillions: TrafficGeneratorPacketsPerSecondInMillionsDefault,
-		PortBandwidthGB:            PortBandwidthGBDefault,
-		TrafficGeneratorMacAddress: trafficGeneratorMacAddressDefault,
-		DPDKMacAddress:             dpdkMacAddressDefault,
-		TestDuration:               TestDurationDefault,
+		PortBandwidthGB:                PortBandwidthGBDefault,
+		TrafficGeneratorEastMacAddress: trafficGeneratorEastMacAddressDefault,
+		DPDKMacAddress:                 dpdkMacAddressDefault,
+		TestDuration:                   TestDurationDefault,
 	}
 
 	var rawNUMASocket string
@@ -125,12 +125,13 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 		newConfig.PortBandwidthGB = portBandwidthGB
 	}
 
-	if rawTrafficGeneratorMacAddress := baseConfig.Params[TrafficGeneratorMacAddressParamName]; rawTrafficGeneratorMacAddress != "" {
-		trafficGeneratorMacAddress, err := net.ParseMAC(rawTrafficGeneratorMacAddress)
+	if rawTrafficGeneratorEastMacAddress :=
+		baseConfig.Params[TrafficGeneratorEastMacAddressParamName]; rawTrafficGeneratorEastMacAddress != "" {
+		trafficGeneratorEastMacAddress, err := net.ParseMAC(rawTrafficGeneratorEastMacAddress)
 		if err != nil {
-			return Config{}, ErrInvalidTrafficGeneratorMacAddress
+			return Config{}, ErrInvalidTrafficGeneratorEastMacAddress
 		}
-		newConfig.TrafficGeneratorMacAddress = trafficGeneratorMacAddress
+		newConfig.TrafficGeneratorEastMacAddress = trafficGeneratorEastMacAddress
 	}
 
 	if rawDPDKMacAddress := baseConfig.Params[DPDKMacAddressParamName]; rawDPDKMacAddress != "" {

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -37,7 +37,7 @@ const (
 	PortBandwidthGBParamName                            = "portBandwidthGB"
 	TrafficGeneratorEastMacAddressParamName             = "trafficGeneratorEastMacAddress"
 	TrafficGeneratorWestMacAddressParamName             = "trafficGeneratorWestMacAddress"
-	DPDKMacAddressParamName                             = "DPDKMacAddress"
+	DPDKEastMacAddressParamName                         = "DPDKEastMacAddress"
 	TestDurationParamName                               = "testDuration"
 )
 
@@ -46,7 +46,7 @@ const (
 	PortBandwidthGBDefault                            = 10
 	TrafficGeneratorEastMacAddressDefault             = "50:00:00:00:00:01"
 	TrafficGeneratorWestMacAddressDefault             = "50:00:00:00:00:02"
-	DPDKMacAddressDefault                             = "60:00:00:00:00:01"
+	DPDKEastMacAddressDefault                         = "60:00:00:00:00:01"
 	TestDurationDefault                               = 5 * time.Minute
 )
 
@@ -59,7 +59,7 @@ var (
 	ErrInvalidPortBandwidthGB                            = errors.New("invalid Port Bandwidth [GB]")
 	ErrInvalidTrafficGeneratorEastMacAddress             = errors.New("invalid Traffic Generator East MAC Address")
 	ErrInvalidTrafficGeneratorWestMacAddress             = errors.New("invalid Traffic Generator West MAC Address")
-	ErrInvalidDPDKMacAddress                             = errors.New("invalid DPDK MAC Address")
+	ErrInvalidDPDKEastMacAddress                         = errors.New("invalid DPDK East MAC Address")
 	ErrInvalidTestDuration                               = errors.New("invalid Test Duration")
 )
 
@@ -74,14 +74,14 @@ type Config struct {
 	PortBandwidthGB                            int
 	TrafficGeneratorEastMacAddress             net.HardwareAddr
 	TrafficGeneratorWestMacAddress             net.HardwareAddr
-	DPDKMacAddress                             net.HardwareAddr
+	DPDKEastMacAddress                         net.HardwareAddr
 	TestDuration                               time.Duration
 }
 
 func New(baseConfig kconfig.Config) (Config, error) {
 	trafficGeneratorEastMacAddressDefault, _ := net.ParseMAC(TrafficGeneratorEastMacAddressDefault)
 	trafficGeneratorWestMacAddressDefault, _ := net.ParseMAC(TrafficGeneratorWestMacAddressDefault)
-	dpdkMacAddressDefault, _ := net.ParseMAC(DPDKMacAddressDefault)
+	dpdkEastMacAddressDefault, _ := net.ParseMAC(DPDKEastMacAddressDefault)
 	newConfig := Config{
 		PodName:                           baseConfig.PodName,
 		PodUID:                            baseConfig.PodUID,
@@ -92,7 +92,7 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		PortBandwidthGB:                PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress: trafficGeneratorEastMacAddressDefault,
 		TrafficGeneratorWestMacAddress: trafficGeneratorWestMacAddressDefault,
-		DPDKMacAddress:                 dpdkMacAddressDefault,
+		DPDKEastMacAddress:             dpdkEastMacAddressDefault,
 		TestDuration:                   TestDurationDefault,
 	}
 
@@ -149,12 +149,12 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 		newConfig.TrafficGeneratorWestMacAddress = trafficGeneratorWestMacAddress
 	}
 
-	if rawDPDKMacAddress := baseConfig.Params[DPDKMacAddressParamName]; rawDPDKMacAddress != "" {
-		dpdkMacAddress, err := net.ParseMAC(rawDPDKMacAddress)
+	if rawDPDKEastMacAddress := baseConfig.Params[DPDKEastMacAddressParamName]; rawDPDKEastMacAddress != "" {
+		dpdkEastMacAddress, err := net.ParseMAC(rawDPDKEastMacAddress)
 		if err != nil {
-			return Config{}, ErrInvalidDPDKMacAddress
+			return Config{}, ErrInvalidDPDKEastMacAddress
 		}
-		newConfig.DPDKMacAddress = dpdkMacAddress
+		newConfig.DPDKEastMacAddress = dpdkEastMacAddress
 	}
 
 	if rawTestDuration := baseConfig.Params[TestDurationParamName]; rawTestDuration != "" {

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -36,6 +36,7 @@ const (
 	TrafficGeneratorPacketsPerSecondInMillionsParamName = "trafficGeneratorPacketsPerSecondInMillions"
 	PortBandwidthGBParamName                            = "portBandwidthGB"
 	TrafficGeneratorEastMacAddressParamName             = "trafficGeneratorEastMacAddress"
+	TrafficGeneratorWestMacAddressParamName             = "trafficGeneratorWestMacAddress"
 	DPDKMacAddressParamName                             = "DPDKMacAddress"
 	TestDurationParamName                               = "testDuration"
 )
@@ -44,6 +45,7 @@ const (
 	TrafficGeneratorPacketsPerSecondInMillionsDefault = 14
 	PortBandwidthGBDefault                            = 10
 	TrafficGeneratorEastMacAddressDefault             = "50:00:00:00:00:01"
+	TrafficGeneratorWestMacAddressDefault             = "50:00:00:00:00:02"
 	DPDKMacAddressDefault                             = "60:00:00:00:00:01"
 	TestDurationDefault                               = 5 * time.Minute
 )
@@ -56,6 +58,7 @@ var (
 	ErrInvalidTrafficGeneratorPacketsPerSecondInMillions = errors.New("invalid Traffic Generator Packets Per Second In Millions")
 	ErrInvalidPortBandwidthGB                            = errors.New("invalid Port Bandwidth [GB]")
 	ErrInvalidTrafficGeneratorEastMacAddress             = errors.New("invalid Traffic Generator East MAC Address")
+	ErrInvalidTrafficGeneratorWestMacAddress             = errors.New("invalid Traffic Generator West MAC Address")
 	ErrInvalidDPDKMacAddress                             = errors.New("invalid DPDK MAC Address")
 	ErrInvalidTestDuration                               = errors.New("invalid Test Duration")
 )
@@ -70,12 +73,14 @@ type Config struct {
 	TrafficGeneratorPacketsPerSecondInMillions int
 	PortBandwidthGB                            int
 	TrafficGeneratorEastMacAddress             net.HardwareAddr
+	TrafficGeneratorWestMacAddress             net.HardwareAddr
 	DPDKMacAddress                             net.HardwareAddr
 	TestDuration                               time.Duration
 }
 
 func New(baseConfig kconfig.Config) (Config, error) {
 	trafficGeneratorEastMacAddressDefault, _ := net.ParseMAC(TrafficGeneratorEastMacAddressDefault)
+	trafficGeneratorWestMacAddressDefault, _ := net.ParseMAC(TrafficGeneratorWestMacAddressDefault)
 	dpdkMacAddressDefault, _ := net.ParseMAC(DPDKMacAddressDefault)
 	newConfig := Config{
 		PodName:                           baseConfig.PodName,
@@ -86,6 +91,7 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		TrafficGeneratorPacketsPerSecondInMillions: TrafficGeneratorPacketsPerSecondInMillionsDefault,
 		PortBandwidthGB:                PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress: trafficGeneratorEastMacAddressDefault,
+		TrafficGeneratorWestMacAddress: trafficGeneratorWestMacAddressDefault,
 		DPDKMacAddress:                 dpdkMacAddressDefault,
 		TestDuration:                   TestDurationDefault,
 	}
@@ -132,6 +138,15 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 			return Config{}, ErrInvalidTrafficGeneratorEastMacAddress
 		}
 		newConfig.TrafficGeneratorEastMacAddress = trafficGeneratorEastMacAddress
+	}
+
+	if rawTrafficGeneratorWestMacAddress :=
+		baseConfig.Params[TrafficGeneratorWestMacAddressParamName]; rawTrafficGeneratorWestMacAddress != "" {
+		trafficGeneratorWestMacAddress, err := net.ParseMAC(rawTrafficGeneratorWestMacAddress)
+		if err != nil {
+			return Config{}, ErrInvalidTrafficGeneratorWestMacAddress
+		}
+		newConfig.TrafficGeneratorWestMacAddress = trafficGeneratorWestMacAddress
 	}
 
 	if rawDPDKMacAddress := baseConfig.Params[DPDKMacAddressParamName]; rawDPDKMacAddress != "" {

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -38,6 +38,7 @@ const (
 	TrafficGeneratorEastMacAddressParamName             = "trafficGeneratorEastMacAddress"
 	TrafficGeneratorWestMacAddressParamName             = "trafficGeneratorWestMacAddress"
 	DPDKEastMacAddressParamName                         = "DPDKEastMacAddress"
+	DPDKWestMacAddressParamName                         = "DPDKWestMacAddress"
 	TestDurationParamName                               = "testDuration"
 )
 
@@ -47,6 +48,7 @@ const (
 	TrafficGeneratorEastMacAddressDefault             = "50:00:00:00:00:01"
 	TrafficGeneratorWestMacAddressDefault             = "50:00:00:00:00:02"
 	DPDKEastMacAddressDefault                         = "60:00:00:00:00:01"
+	DPDKWestMacAddressDefault                         = "60:00:00:00:00:02"
 	TestDurationDefault                               = 5 * time.Minute
 )
 
@@ -60,6 +62,7 @@ var (
 	ErrInvalidTrafficGeneratorEastMacAddress             = errors.New("invalid Traffic Generator East MAC Address")
 	ErrInvalidTrafficGeneratorWestMacAddress             = errors.New("invalid Traffic Generator West MAC Address")
 	ErrInvalidDPDKEastMacAddress                         = errors.New("invalid DPDK East MAC Address")
+	ErrInvalidDPDKWestMacAddress                         = errors.New("invalid DPDK West MAC Address")
 	ErrInvalidTestDuration                               = errors.New("invalid Test Duration")
 )
 
@@ -75,6 +78,7 @@ type Config struct {
 	TrafficGeneratorEastMacAddress             net.HardwareAddr
 	TrafficGeneratorWestMacAddress             net.HardwareAddr
 	DPDKEastMacAddress                         net.HardwareAddr
+	DPDKWestMacAddress                         net.HardwareAddr
 	TestDuration                               time.Duration
 }
 
@@ -82,6 +86,7 @@ func New(baseConfig kconfig.Config) (Config, error) {
 	trafficGeneratorEastMacAddressDefault, _ := net.ParseMAC(TrafficGeneratorEastMacAddressDefault)
 	trafficGeneratorWestMacAddressDefault, _ := net.ParseMAC(TrafficGeneratorWestMacAddressDefault)
 	dpdkEastMacAddressDefault, _ := net.ParseMAC(DPDKEastMacAddressDefault)
+	dpdkWestMacAddressDefault, _ := net.ParseMAC(DPDKWestMacAddressDefault)
 	newConfig := Config{
 		PodName:                           baseConfig.PodName,
 		PodUID:                            baseConfig.PodUID,
@@ -93,6 +98,7 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		TrafficGeneratorEastMacAddress: trafficGeneratorEastMacAddressDefault,
 		TrafficGeneratorWestMacAddress: trafficGeneratorWestMacAddressDefault,
 		DPDKEastMacAddress:             dpdkEastMacAddressDefault,
+		DPDKWestMacAddress:             dpdkWestMacAddressDefault,
 		TestDuration:                   TestDurationDefault,
 	}
 
@@ -155,6 +161,14 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 			return Config{}, ErrInvalidDPDKEastMacAddress
 		}
 		newConfig.DPDKEastMacAddress = dpdkEastMacAddress
+	}
+
+	if rawDPDKWestMacAddress := baseConfig.Params[DPDKWestMacAddressParamName]; rawDPDKWestMacAddress != "" {
+		dpdkWestMacAddress, err := net.ParseMAC(rawDPDKWestMacAddress)
+		if err != nil {
+			return Config{}, ErrInvalidDPDKWestMacAddress
+		}
+		newConfig.DPDKWestMacAddress = dpdkWestMacAddress
 	}
 
 	if rawTestDuration := baseConfig.Params[TestDurationParamName]; rawTestDuration != "" {

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -42,6 +42,7 @@ const (
 	trafficGeneratorPacketsPerSecondInMillions = 6
 	dpdkNodeLabelSelector                      = "node-role.kubernetes.io/worker-dpdk2"
 	trafficGeneratorEastMacAddress             = "DE:AD:BE:EF:00:01"
+	trafficGeneratorWestMacAddress             = "DE:AD:BE:EF:01:00"
 	dpdkMacAddress                             = "DE:AD:BE:EF:00:02"
 	testDuration                               = "30m"
 )
@@ -60,6 +61,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 	assert.NoError(t, err)
 
 	trafficGeneratorEastMacAddressDefault, _ := net.ParseMAC(config.TrafficGeneratorEastMacAddressDefault)
+	trafficGeneratorWestMacAddressDefault, _ := net.ParseMAC(config.TrafficGeneratorWestMacAddressDefault)
 	dpdkMacAddressDefault, _ := net.ParseMAC(config.DPDKMacAddressDefault)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
@@ -69,6 +71,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		TrafficGeneratorPacketsPerSecondInMillions: config.TrafficGeneratorPacketsPerSecondInMillionsDefault,
 		PortBandwidthGB:                config.PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress: trafficGeneratorEastMacAddressDefault,
+		TrafficGeneratorWestMacAddress: trafficGeneratorWestMacAddressDefault,
 		DPDKMacAddress:                 dpdkMacAddressDefault,
 		TestDuration:                   config.TestDurationDefault,
 	}
@@ -86,6 +89,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	trafficGeneratorEastHWAddress, _ := net.ParseMAC(trafficGeneratorEastMacAddress)
+	trafficGeneratorWestHWAddress, _ := net.ParseMAC(trafficGeneratorWestMacAddress)
 	dpdkHWAddress, _ := net.ParseMAC(dpdkMacAddress)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
@@ -97,6 +101,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 		TrafficGeneratorNodeLabelSelector:          trafficGeneratorNodeLabelSelector,
 		DPDKNodeLabelSelector:                      dpdkNodeLabelSelector,
 		TrafficGeneratorEastMacAddress:             trafficGeneratorEastHWAddress,
+		TrafficGeneratorWestMacAddress:             trafficGeneratorWestHWAddress,
 		DPDKMacAddress:                             dpdkHWAddress,
 		TestDuration:                               30 * time.Minute,
 	}
@@ -149,6 +154,12 @@ func TestNewShouldFailWhen(t *testing.T) {
 			expectedError:  config.ErrInvalidTrafficGeneratorEastMacAddress,
 		},
 		{
+			description:    "TrafficGeneratorWestMacAddress is invalid",
+			key:            config.TrafficGeneratorWestMacAddressParamName,
+			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
+			expectedError:  config.ErrInvalidTrafficGeneratorWestMacAddress,
+		},
+		{
 			description:    "DPDKMacAddress is invalid",
 			key:            config.DPDKMacAddressParamName,
 			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
@@ -188,6 +199,7 @@ func getValidUserParameters() map[string]string {
 		config.TrafficGeneratorPacketsPerSecondInMillionsParamName: fmt.Sprintf("%d", trafficGeneratorPacketsPerSecondInMillions),
 		config.DPDKNodeLabelSelectorParamName:                      dpdkNodeLabelSelector,
 		config.TrafficGeneratorEastMacAddressParamName:             trafficGeneratorEastMacAddress,
+		config.TrafficGeneratorWestMacAddressParamName:             trafficGeneratorWestMacAddress,
 		config.DPDKMacAddressParamName:                             dpdkMacAddress,
 		config.TestDurationParamName:                               testDuration,
 	}

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -44,6 +44,7 @@ const (
 	trafficGeneratorEastMacAddress             = "DE:AD:BE:EF:00:01"
 	trafficGeneratorWestMacAddress             = "DE:AD:BE:EF:01:00"
 	dpdkEastMacAddress                         = "DE:AD:BE:EF:00:02"
+	dpdkWestMacAddress                         = "DE:AD:BE:EF:02:00"
 	testDuration                               = "30m"
 )
 
@@ -63,6 +64,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 	trafficGeneratorEastMacAddressDefault, _ := net.ParseMAC(config.TrafficGeneratorEastMacAddressDefault)
 	trafficGeneratorWestMacAddressDefault, _ := net.ParseMAC(config.TrafficGeneratorWestMacAddressDefault)
 	dpdkEastMacAddressDefault, _ := net.ParseMAC(config.DPDKEastMacAddressDefault)
+	dpdkWestMacAddressDefault, _ := net.ParseMAC(config.DPDKWestMacAddressDefault)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
 		PodUID:                          testPodUID,
@@ -73,6 +75,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		TrafficGeneratorEastMacAddress: trafficGeneratorEastMacAddressDefault,
 		TrafficGeneratorWestMacAddress: trafficGeneratorWestMacAddressDefault,
 		DPDKEastMacAddress:             dpdkEastMacAddressDefault,
+		DPDKWestMacAddress:             dpdkWestMacAddressDefault,
 		TestDuration:                   config.TestDurationDefault,
 	}
 	assert.Equal(t, expectedConfig, actualConfig)
@@ -91,6 +94,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 	trafficGeneratorEastHWAddress, _ := net.ParseMAC(trafficGeneratorEastMacAddress)
 	trafficGeneratorWestHWAddress, _ := net.ParseMAC(trafficGeneratorWestMacAddress)
 	dpdkEastHWAddress, _ := net.ParseMAC(dpdkEastMacAddress)
+	dpdkWestHWAddress, _ := net.ParseMAC(dpdkWestMacAddress)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
 		PodUID:                          testPodUID,
@@ -103,6 +107,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 		TrafficGeneratorEastMacAddress:             trafficGeneratorEastHWAddress,
 		TrafficGeneratorWestMacAddress:             trafficGeneratorWestHWAddress,
 		DPDKEastMacAddress:                         dpdkEastHWAddress,
+		DPDKWestMacAddress:                         dpdkWestHWAddress,
 		TestDuration:                               30 * time.Minute,
 	}
 	assert.Equal(t, expectedConfig, actualConfig)
@@ -166,6 +171,12 @@ func TestNewShouldFailWhen(t *testing.T) {
 			expectedError:  config.ErrInvalidDPDKEastMacAddress,
 		},
 		{
+			description:    "DPDKWestMacAddress is invalid",
+			key:            config.DPDKWestMacAddressParamName,
+			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
+			expectedError:  config.ErrInvalidDPDKWestMacAddress,
+		},
+		{
 			description:    "TestDuration is invalid",
 			key:            config.TestDurationParamName,
 			faultyKeyValue: "invalid value",
@@ -201,6 +212,7 @@ func getValidUserParameters() map[string]string {
 		config.TrafficGeneratorEastMacAddressParamName:             trafficGeneratorEastMacAddress,
 		config.TrafficGeneratorWestMacAddressParamName:             trafficGeneratorWestMacAddress,
 		config.DPDKEastMacAddressParamName:                         dpdkEastMacAddress,
+		config.DPDKWestMacAddressParamName:                         dpdkWestMacAddress,
 		config.TestDurationParamName:                               testDuration,
 	}
 }

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -43,7 +43,7 @@ const (
 	dpdkNodeLabelSelector                      = "node-role.kubernetes.io/worker-dpdk2"
 	trafficGeneratorEastMacAddress             = "DE:AD:BE:EF:00:01"
 	trafficGeneratorWestMacAddress             = "DE:AD:BE:EF:01:00"
-	dpdkMacAddress                             = "DE:AD:BE:EF:00:02"
+	dpdkEastMacAddress                         = "DE:AD:BE:EF:00:02"
 	testDuration                               = "30m"
 )
 
@@ -62,7 +62,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 
 	trafficGeneratorEastMacAddressDefault, _ := net.ParseMAC(config.TrafficGeneratorEastMacAddressDefault)
 	trafficGeneratorWestMacAddressDefault, _ := net.ParseMAC(config.TrafficGeneratorWestMacAddressDefault)
-	dpdkMacAddressDefault, _ := net.ParseMAC(config.DPDKMacAddressDefault)
+	dpdkEastMacAddressDefault, _ := net.ParseMAC(config.DPDKEastMacAddressDefault)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
 		PodUID:                          testPodUID,
@@ -72,7 +72,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		PortBandwidthGB:                config.PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress: trafficGeneratorEastMacAddressDefault,
 		TrafficGeneratorWestMacAddress: trafficGeneratorWestMacAddressDefault,
-		DPDKMacAddress:                 dpdkMacAddressDefault,
+		DPDKEastMacAddress:             dpdkEastMacAddressDefault,
 		TestDuration:                   config.TestDurationDefault,
 	}
 	assert.Equal(t, expectedConfig, actualConfig)
@@ -90,7 +90,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 
 	trafficGeneratorEastHWAddress, _ := net.ParseMAC(trafficGeneratorEastMacAddress)
 	trafficGeneratorWestHWAddress, _ := net.ParseMAC(trafficGeneratorWestMacAddress)
-	dpdkHWAddress, _ := net.ParseMAC(dpdkMacAddress)
+	dpdkEastHWAddress, _ := net.ParseMAC(dpdkEastMacAddress)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
 		PodUID:                          testPodUID,
@@ -102,7 +102,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 		DPDKNodeLabelSelector:                      dpdkNodeLabelSelector,
 		TrafficGeneratorEastMacAddress:             trafficGeneratorEastHWAddress,
 		TrafficGeneratorWestMacAddress:             trafficGeneratorWestHWAddress,
-		DPDKMacAddress:                             dpdkHWAddress,
+		DPDKEastMacAddress:                         dpdkEastHWAddress,
 		TestDuration:                               30 * time.Minute,
 	}
 	assert.Equal(t, expectedConfig, actualConfig)
@@ -160,10 +160,10 @@ func TestNewShouldFailWhen(t *testing.T) {
 			expectedError:  config.ErrInvalidTrafficGeneratorWestMacAddress,
 		},
 		{
-			description:    "DPDKMacAddress is invalid",
-			key:            config.DPDKMacAddressParamName,
+			description:    "DPDKEastMacAddress is invalid",
+			key:            config.DPDKEastMacAddressParamName,
 			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
-			expectedError:  config.ErrInvalidDPDKMacAddress,
+			expectedError:  config.ErrInvalidDPDKEastMacAddress,
 		},
 		{
 			description:    "TestDuration is invalid",
@@ -200,7 +200,7 @@ func getValidUserParameters() map[string]string {
 		config.DPDKNodeLabelSelectorParamName:                      dpdkNodeLabelSelector,
 		config.TrafficGeneratorEastMacAddressParamName:             trafficGeneratorEastMacAddress,
 		config.TrafficGeneratorWestMacAddressParamName:             trafficGeneratorWestMacAddress,
-		config.DPDKMacAddressParamName:                             dpdkMacAddress,
+		config.DPDKEastMacAddressParamName:                         dpdkEastMacAddress,
 		config.TestDurationParamName:                               testDuration,
 	}
 }

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -41,7 +41,7 @@ const (
 	trafficGeneratorNodeLabelSelector          = "node-role.kubernetes.io/worker-dpdk1"
 	trafficGeneratorPacketsPerSecondInMillions = 6
 	dpdkNodeLabelSelector                      = "node-role.kubernetes.io/worker-dpdk2"
-	trafficGeneratorMacAddress                 = "DE:AD:BE:EF:00:01"
+	trafficGeneratorEastMacAddress             = "DE:AD:BE:EF:00:01"
 	dpdkMacAddress                             = "DE:AD:BE:EF:00:02"
 	testDuration                               = "30m"
 )
@@ -59,7 +59,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 	actualConfig, err := config.New(baseConfig)
 	assert.NoError(t, err)
 
-	trafficGeneratorMacAddressDefault, _ := net.ParseMAC(config.TrafficGeneratorMacAddressDefault)
+	trafficGeneratorEastMacAddressDefault, _ := net.ParseMAC(config.TrafficGeneratorEastMacAddressDefault)
 	dpdkMacAddressDefault, _ := net.ParseMAC(config.DPDKMacAddressDefault)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
@@ -67,10 +67,10 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		NUMASocket:                      numaSocket,
 		NetworkAttachmentDefinitionName: networkAttachmentDefinitionName,
 		TrafficGeneratorPacketsPerSecondInMillions: config.TrafficGeneratorPacketsPerSecondInMillionsDefault,
-		PortBandwidthGB:            config.PortBandwidthGBDefault,
-		TrafficGeneratorMacAddress: trafficGeneratorMacAddressDefault,
-		DPDKMacAddress:             dpdkMacAddressDefault,
-		TestDuration:               config.TestDurationDefault,
+		PortBandwidthGB:                config.PortBandwidthGBDefault,
+		TrafficGeneratorEastMacAddress: trafficGeneratorEastMacAddressDefault,
+		DPDKMacAddress:                 dpdkMacAddressDefault,
+		TestDuration:                   config.TestDurationDefault,
 	}
 	assert.Equal(t, expectedConfig, actualConfig)
 }
@@ -85,7 +85,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 	actualConfig, err := config.New(baseConfig)
 	assert.NoError(t, err)
 
-	trafficGeneratorHWAddress, _ := net.ParseMAC(trafficGeneratorMacAddress)
+	trafficGeneratorEastHWAddress, _ := net.ParseMAC(trafficGeneratorEastMacAddress)
 	dpdkHWAddress, _ := net.ParseMAC(dpdkMacAddress)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
@@ -96,7 +96,7 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 		TrafficGeneratorPacketsPerSecondInMillions: trafficGeneratorPacketsPerSecondInMillions,
 		TrafficGeneratorNodeLabelSelector:          trafficGeneratorNodeLabelSelector,
 		DPDKNodeLabelSelector:                      dpdkNodeLabelSelector,
-		TrafficGeneratorMacAddress:                 trafficGeneratorHWAddress,
+		TrafficGeneratorEastMacAddress:             trafficGeneratorEastHWAddress,
 		DPDKMacAddress:                             dpdkHWAddress,
 		TestDuration:                               30 * time.Minute,
 	}
@@ -143,10 +143,10 @@ func TestNewShouldFailWhen(t *testing.T) {
 			expectedError:  config.ErrInvalidPortBandwidthGB,
 		},
 		{
-			description:    "TrafficGeneratorMacAddress is invalid",
-			key:            config.TrafficGeneratorMacAddressParamName,
+			description:    "TrafficGeneratorEastMacAddress is invalid",
+			key:            config.TrafficGeneratorEastMacAddressParamName,
 			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
-			expectedError:  config.ErrInvalidTrafficGeneratorMacAddress,
+			expectedError:  config.ErrInvalidTrafficGeneratorEastMacAddress,
 		},
 		{
 			description:    "DPDKMacAddress is invalid",
@@ -187,7 +187,7 @@ func getValidUserParameters() map[string]string {
 		config.TrafficGeneratorNodeLabelSelectorParamName:          trafficGeneratorNodeLabelSelector,
 		config.TrafficGeneratorPacketsPerSecondInMillionsParamName: fmt.Sprintf("%d", trafficGeneratorPacketsPerSecondInMillions),
 		config.DPDKNodeLabelSelectorParamName:                      dpdkNodeLabelSelector,
-		config.TrafficGeneratorMacAddressParamName:                 trafficGeneratorMacAddress,
+		config.TrafficGeneratorEastMacAddressParamName:             trafficGeneratorEastMacAddress,
 		config.DPDKMacAddressParamName:                             dpdkMacAddress,
 		config.TestDurationParamName:                               testDuration,
 	}

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -65,6 +65,6 @@ func printConfig(checkupConfig config.Config) {
 		checkupConfig.TrafficGeneratorPacketsPerSecondInMillions)
 	log.Printf("\t%q: %q", config.DPDKNodeLabelSelectorParamName, checkupConfig.DPDKNodeLabelSelector)
 	log.Printf("\t%q: %q", config.TrafficGeneratorEastMacAddressParamName, checkupConfig.TrafficGeneratorEastMacAddress)
-	log.Printf("\t%q: %q", config.DPDKMacAddressParamName, checkupConfig.DPDKMacAddress)
+	log.Printf("\t%q: %q", config.DPDKEastMacAddressParamName, checkupConfig.DPDKEastMacAddress)
 	log.Printf("\t%q: %q", config.TestDurationParamName, checkupConfig.TestDuration)
 }

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -64,7 +64,7 @@ func printConfig(checkupConfig config.Config) {
 	log.Printf("\t%q: %q", config.TrafficGeneratorPacketsPerSecondInMillionsParamName,
 		checkupConfig.TrafficGeneratorPacketsPerSecondInMillions)
 	log.Printf("\t%q: %q", config.DPDKNodeLabelSelectorParamName, checkupConfig.DPDKNodeLabelSelector)
-	log.Printf("\t%q: %q", config.TrafficGeneratorMacAddressParamName, checkupConfig.TrafficGeneratorMacAddress)
+	log.Printf("\t%q: %q", config.TrafficGeneratorEastMacAddressParamName, checkupConfig.TrafficGeneratorEastMacAddress)
 	log.Printf("\t%q: %q", config.DPDKMacAddressParamName, checkupConfig.DPDKMacAddress)
 	log.Printf("\t%q: %q", config.TestDurationParamName, checkupConfig.TestDuration)
 }


### PR DESCRIPTION
According to trex [manual](https://trex-tgn.cisco.com/trex/doc/trex_manual.html#_creating_minimum_configuration_file), we need 2 NICs per trex pod and testpmd - this is to run inbound and outbound traffic on separate paths. 

This PR splits the MAC address param of both Traffic generator and DPDK to west and east params.