### PR TITLE
checkup, setup: Add VirtualMachineInstance creation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,12 @@ func main() {
 
 	const errMessagePrefix = "kubevirt-dpdk-checkup failed"
 
-	if err := pkg.Run(rawEnv); err != nil {
+	namespace, err := environment.ReadNamespaceFile()
+	if err != nil {
+		log.Fatalf("%s: %v\n", errMessagePrefix, err)
+	}
+
+	if err = pkg.Run(rawEnv, namespace); err != nil {
 		log.Fatalf("%s: %v\n", errMessagePrefix, err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v12.0.0+incompatible
+	kubevirt.io/api v0.0.0-20221013011232-17665f214e18
 	kubevirt.io/client-go v0.58.0
 )
 
@@ -57,7 +58,6 @@ require (
 	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
-	kubevirt.io/api v0.0.0-20221013011232-17665f214e18 // indirect
 	kubevirt.io/containerized-data-importer-api v1.50.0 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -21,18 +21,46 @@ package checkup
 
 import (
 	"context"
+	"fmt"
 
+	k8srand "k8s.io/apimachinery/pkg/util/rand"
+
+	kvcorev1 "kubevirt.io/api/core/v1"
+
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/vmi"
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/config"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/status"
 )
 
-type Checkup struct {
+type kubeVirtVMIClient interface {
+	CreateVirtualMachineInstance(ctx context.Context,
+		namespace string,
+		vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
 }
 
-func New() *Checkup {
-	return &Checkup{}
+type Checkup struct {
+	client    kubeVirtVMIClient
+	namespace string
+	vmi       *kvcorev1.VirtualMachineInstance
+}
+
+const VMINamePrefix = "dpdk-vmi"
+
+func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config) *Checkup {
+	return &Checkup{
+		client:    client,
+		namespace: namespace,
+		vmi:       newDPDKVMI(checkupConfig),
+	}
 }
 
 func (c *Checkup) Setup(ctx context.Context) error {
+	createdVMI, err := c.client.CreateVirtualMachineInstance(ctx, c.namespace, c.vmi)
+	if err != nil {
+		return err
+	}
+	c.vmi = createdVMI
+
 	return nil
 }
 
@@ -46,4 +74,53 @@ func (c *Checkup) Teardown(ctx context.Context) error {
 
 func (c *Checkup) Results() status.Results {
 	return status.Results{}
+}
+
+func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
+	const (
+		CPUSocketsCount   = 1
+		CPUCoresCount     = 4
+		CPUTreadsCount    = 2
+		rootDiskName      = "rootdisk"
+		cloudInitDiskName = "cloudinitdisk"
+		userData          = `#cloud-config
+user: cloud-user
+password: 0tli-pxem-xknu
+chpasswd:
+  expire: false`
+
+		eastNetworkName   = "nic-east"
+		eastNICPCIAddress = "0000:06:00.0"
+		westNetworkName   = "nic-west"
+		westNICPCIAddress = "0000:07:00.0"
+
+		terminationGracePeriodSeconds = 180
+	)
+
+	return vmi.New(randomizeName(VMINamePrefix),
+		vmi.WithoutCRIOCPULoadBalancing(),
+		vmi.WithoutCRIOCPUQuota(),
+		vmi.WithoutCRIOIRQLoadBalancing(),
+		vmi.WithDedicatedCPU(CPUSocketsCount, CPUCoresCount, CPUTreadsCount),
+		vmi.WithSRIOVInterface(eastNetworkName, checkupConfig.DPDKEastMacAddress.String(), eastNICPCIAddress),
+		vmi.WithMultusNetwork(eastNetworkName, checkupConfig.NetworkAttachmentDefinitionName),
+		vmi.WithSRIOVInterface(westNetworkName, checkupConfig.DPDKWestMacAddress.String(), westNICPCIAddress),
+		vmi.WithMultusNetwork(westNetworkName, checkupConfig.NetworkAttachmentDefinitionName),
+		vmi.WithNetworkInterfaceMultiQueue(),
+		vmi.WithRandomNumberGenerator(),
+		vmi.WithHugePages(),
+		vmi.WithMemoryRequest("8Gi"),
+		vmi.WithTerminationGracePeriodSeconds(terminationGracePeriodSeconds),
+		vmi.WithNodeSelector(checkupConfig.DPDKNodeLabelSelector),
+		vmi.WithPVCVolume(rootDiskName, "rhel8-yummy-gorilla"),
+		vmi.WithVirtIODisk(rootDiskName),
+		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, userData),
+		vmi.WithVirtIODisk(cloudInitDiskName),
+	)
+}
+
+func randomizeName(prefix string) string {
+	const randomStringLen = 5
+
+	return fmt.Sprintf("%s-%s", prefix, k8srand.String(randomStringLen))
 }

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -1,0 +1,228 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vmi
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kvcorev1 "kubevirt.io/api/core/v1"
+)
+
+// Based on annotation names from:
+// https://github.com/cri-o/cri-o/blob/fa0fa5de1c17ddd7b6fcdbc030b6b571ce37e643/pkg/annotations/annotations.go
+
+const (
+	// CRIOCPULoadBalancingAnnotation indicates that load balancing should be disabled for CPUs used by the container
+	CRIOCPULoadBalancingAnnotation = "cpu-load-balancing.crio.io"
+
+	// CRIOCPUQuotaAnnotation indicates that CPU quota should be disabled for CPUs used by the container
+	CRIOCPUQuotaAnnotation = "cpu-quota.crio.io"
+
+	// CRIOIRQLoadBalancingAnnotation indicates that IRQ load balancing should be disabled for CPUs used by the container
+	CRIOIRQLoadBalancingAnnotation = "irq-load-balancing.crio.io"
+)
+
+const Disable = "disable"
+
+type Option func(vmi *kvcorev1.VirtualMachineInstance)
+
+func New(name string, options ...Option) *kvcorev1.VirtualMachineInstance {
+	newVMI := &kvcorev1.VirtualMachineInstance{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kvcorev1.VirtualMachineInstanceGroupVersionKind.Kind,
+			APIVersion: kvcorev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	for _, f := range options {
+		f(newVMI)
+	}
+
+	return newVMI
+}
+
+func WithoutCRIOCPULoadBalancing() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if vmi.ObjectMeta.Annotations == nil {
+			vmi.ObjectMeta.Annotations = map[string]string{}
+		}
+
+		vmi.ObjectMeta.Annotations[CRIOCPULoadBalancingAnnotation] = Disable
+	}
+}
+
+func WithoutCRIOCPUQuota() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if vmi.ObjectMeta.Annotations == nil {
+			vmi.ObjectMeta.Annotations = map[string]string{}
+		}
+
+		vmi.ObjectMeta.Annotations[CRIOCPUQuotaAnnotation] = Disable
+	}
+}
+
+func WithoutCRIOIRQLoadBalancing() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if vmi.ObjectMeta.Annotations == nil {
+			vmi.ObjectMeta.Annotations = map[string]string{}
+		}
+
+		vmi.ObjectMeta.Annotations[CRIOIRQLoadBalancingAnnotation] = Disable
+	}
+}
+
+func WithDedicatedCPU(socketsCount, coresCount, threadsCount uint32) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.CPU = &kvcorev1.CPU{
+			Sockets:               socketsCount,
+			Cores:                 coresCount,
+			Threads:               threadsCount,
+			DedicatedCPUPlacement: true,
+		}
+	}
+}
+
+func WithVirtIODisk(name string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, kvcorev1.Disk{
+			Name: name,
+			DiskDevice: kvcorev1.DiskDevice{
+				Disk: &kvcorev1.DiskTarget{Bus: kvcorev1.DiskBusVirtio},
+			},
+		})
+	}
+}
+
+func WithSRIOVInterface(name, macAddress, pciAddress string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, kvcorev1.Interface{
+			Name:       name,
+			Model:      "virtio",
+			MacAddress: macAddress,
+			PciAddress: pciAddress,
+			InterfaceBindingMethod: kvcorev1.InterfaceBindingMethod{
+				SRIOV: &kvcorev1.InterfaceSRIOV{},
+			},
+		})
+	}
+}
+
+func WithNetworkInterfaceMultiQueue() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = Pointer(true)
+	}
+}
+
+func WithRandomNumberGenerator() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Rng = &kvcorev1.Rng{}
+	}
+}
+
+func WithHugePages() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Memory = &kvcorev1.Memory{
+			Hugepages: &kvcorev1.Hugepages{PageSize: "1Gi"},
+		}
+	}
+}
+
+func WithMemoryRequest(memory string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Resources = kvcorev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse(memory),
+			},
+		}
+	}
+}
+
+func WithTerminationGracePeriodSeconds(terminationGracePeriodSeconds int64) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.TerminationGracePeriodSeconds = Pointer(terminationGracePeriodSeconds)
+	}
+}
+
+func WithNodeSelector(nodeName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if nodeName == "" {
+			return
+		}
+
+		if vmi.Spec.NodeSelector == nil {
+			vmi.Spec.NodeSelector = map[string]string{}
+		}
+
+		vmi.Spec.NodeSelector[corev1.LabelHostname] = nodeName
+	}
+}
+
+func WithMultusNetwork(name, networkAttachmentDefinitionName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Networks = append(vmi.Spec.Networks, kvcorev1.Network{
+			Name: name,
+			NetworkSource: kvcorev1.NetworkSource{
+				Multus: &kvcorev1.MultusNetwork{
+					NetworkName: networkAttachmentDefinitionName,
+				},
+			},
+		})
+	}
+}
+
+func WithPVCVolume(volumeName, pvcName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		newVolume := kvcorev1.Volume{
+			Name: volumeName,
+			VolumeSource: kvcorev1.VolumeSource{
+				PersistentVolumeClaim: &kvcorev1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+					},
+				},
+			},
+		}
+
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newVolume)
+	}
+}
+
+func WithCloudInitNoCloudVolume(name, userData string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		newVolume := kvcorev1.Volume{
+			Name: name,
+			VolumeSource: kvcorev1.VolumeSource{
+				CloudInitNoCloud: &kvcorev1.CloudInitNoCloudSource{
+					UserData: userData,
+				},
+			},
+		}
+
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newVolume)
+	}
+}
+
+func Pointer[T any](v T) *T {
+	return &v
+}

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -52,7 +52,10 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 	l := launcher.New(checkup.New(), reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName))
 
-	return l.Run(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), baseConfig.Timeout)
+	defer cancel()
+
+	return l.Run(ctx)
 }
 
 func printConfig(checkupConfig config.Config) {

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -50,7 +50,7 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 	printConfig(cfg)
 
-	l := launcher.New(checkup.New(), reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName))
+	l := launcher.New(checkup.New(c, namespace, cfg), reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), baseConfig.Timeout)
 	defer cancel()

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/reporter"
 )
 
-func Run(rawEnv map[string]string) error {
+func Run(rawEnv map[string]string, namespace string) error {
 	c, err := client.New()
 	if err != nil {
 		return err

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -328,6 +328,7 @@ k8s.io/apimachinery/pkg/util/managedfields
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/strategicpatch


### PR DESCRIPTION
Create the VirtualMachineInstance object to be used as a test subject.

A follow-up PR will also wait for the VMI to boot.

The VMI object is created with a random suffix, in order to enable execution of multiple checkup instances simultaneously.

Manually tested against an OpenShift Virtualization 4.11 cluster.

Based on PR https://github.com/kiagnose/kubevirt-rt-checkup/pull/17