### PR TITLE
Makefile: Make go tools ignore go and linter cache dirs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,5 @@
 .github
 
 # Cache
-linter-cache
-go-cache
+_linter-cache
+_go-cache

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ _output
 # vendor/
 
 # Cache
-linter-cache
-go-cache
+_linter-cache
+_go-cache

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ all: check build
 check: lint test/unit
 
 build:
-	mkdir -p $(CURDIR)/go-cache
+	mkdir -p $(CURDIR)/_go-cache
 	$(CRI_BIN) run --rm \
 	           --volume $(CURDIR):$(CURDIR):Z \
-	           --volume $(CURDIR)/go-cache:/root/.cache/go-build:Z \
+	           --volume $(CURDIR)/_go-cache:/root/.cache/go-build:Z \
 	           --workdir $(CURDIR) \
 	           -e GOOS=linux \
 	           -e GOARCH=amd64 \
@@ -38,10 +38,10 @@ push:
 .PHONY: push
 
 test/unit:
-	mkdir -p $(CURDIR)/go-cache
+	mkdir -p $(CURDIR)/_go-cache
 	$(CRI_BIN) run --rm \
 	           --volume $(CURDIR):$(CURDIR):Z \
-	           --volume $(CURDIR)/go-cache:/root/.cache/go-build:Z \
+	           --volume $(CURDIR)/_go-cache:/root/.cache/go-build:Z \
 	           --workdir $(CURDIR) \
 	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go test -v ./cmd/... ./pkg/...
 .PHONY: test/unit
@@ -59,10 +59,10 @@ test/e2e:
 .PHONY: test/e2e
 
 lint:
-	mkdir -p $(CURDIR)/linter-cache
+	mkdir -p $(CURDIR)/_linter-cache
 	$(CRI_BIN) run --rm \
 	           --volume $(CURDIR):$(CURDIR):Z \
-	           --volume $(CURDIR)/linter-cache:/root/.cache:Z \
+	           --volume $(CURDIR)/_linter-cache:/root/.cache:Z \
 	           --workdir $(CURDIR) \
 	            $(LINTER_IMAGE_NAME):$(LINTER_IMAGE_TAG) golangci-lint run --timeout 3m ./cmd/... ./pkg/... ./tests/...
 .PHONY: lint


### PR DESCRIPTION
Currently, if the linter cache directory exists,
the `go mod tidy` command fails, because it doesn't have permissions to read it.

Add an underscore as a prefix to the `go-cache`
and `linter-cache` directories, so the `go mod tidy` command will ignore them[1].

Apply to `.gitignore` and `.dockerignore` as well.

[1] https://pkg.go.dev/cmd/go#hdr-Package_lists_and_patterns

Based on PR https://github.com/kiagnose/kubevirt-rt-checkup/pull/18.

Signed-off-by: Orel Misan <omisan@redhat.com>