### PR TITLE
checkup, teardown: Delete the VMI and wait for its deletion

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -23,8 +23,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8srand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 
@@ -37,6 +40,7 @@ type kubeVirtVMIClient interface {
 	CreateVirtualMachineInstance(ctx context.Context,
 		namespace string,
 		vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
+	GetVirtualMachineInstance(ctx context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error)
 	DeleteVirtualMachineInstance(ctx context.Context, namespace, name string) error
 }
 
@@ -77,6 +81,10 @@ func (c *Checkup) Teardown(ctx context.Context) error {
 		return fmt.Errorf("%s: %w", errPrefix, err)
 	}
 
+	if err := c.waitForVMIDeletion(ctx); err != nil {
+		return fmt.Errorf("%s: %w", errPrefix, err)
+	}
+
 	return nil
 }
 
@@ -96,6 +104,27 @@ func (c *Checkup) deleteVMI(ctx context.Context) error {
 		log.Printf("Failed to delete VMI: %q", vmiFullName)
 		return err
 	}
+
+	return nil
+}
+
+func (c *Checkup) waitForVMIDeletion(ctx context.Context) error {
+	vmiFullName := ObjectFullName(c.vmi.Namespace, c.vmi.Name)
+	log.Printf("Waiting for VMI %q to be deleted...", vmiFullName)
+
+	conditionFn := func(ctx context.Context) (bool, error) {
+		_, err := c.client.GetVirtualMachineInstance(ctx, c.vmi.Namespace, c.vmi.Name)
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	const pollInterval = 5 * time.Second
+	if err := wait.PollImmediateUntilWithContext(ctx, pollInterval, conditionFn); err != nil {
+		return fmt.Errorf("failed to wait for VMI %q to be deleted: %v", vmiFullName, err)
+	}
+
+	log.Printf("VMI %q was deleted successfully", vmiFullName)
 
 	return nil
 }

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -22,6 +22,7 @@ package checkup
 import (
 	"context"
 	"fmt"
+	"log"
 
 	k8srand "k8s.io/apimachinery/pkg/util/rand"
 
@@ -36,6 +37,7 @@ type kubeVirtVMIClient interface {
 	CreateVirtualMachineInstance(ctx context.Context,
 		namespace string,
 		vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
+	DeleteVirtualMachineInstance(ctx context.Context, namespace, name string) error
 }
 
 type Checkup struct {
@@ -69,11 +71,37 @@ func (c *Checkup) Run(ctx context.Context) error {
 }
 
 func (c *Checkup) Teardown(ctx context.Context) error {
+	const errPrefix = "teardown"
+
+	if err := c.deleteVMI(ctx); err != nil {
+		return fmt.Errorf("%s: %w", errPrefix, err)
+	}
+
 	return nil
 }
 
 func (c *Checkup) Results() status.Results {
 	return status.Results{}
+}
+
+func (c *Checkup) deleteVMI(ctx context.Context) error {
+	if c.vmi == nil {
+		return fmt.Errorf("failed to delete VMI, object doesn't exist")
+	}
+
+	vmiFullName := ObjectFullName(c.vmi.Namespace, c.vmi.Name)
+
+	log.Printf("Trying to delete VMI: %q", vmiFullName)
+	if err := c.client.DeleteVirtualMachineInstance(ctx, c.vmi.Namespace, c.vmi.Name); err != nil {
+		log.Printf("Failed to delete VMI: %q", vmiFullName)
+		return err
+	}
+
+	return nil
+}
+
+func ObjectFullName(namespace, name string) string {
+	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
 func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -89,6 +89,20 @@ func TestTeardownShouldFailWhen(t *testing.T) {
 
 		assert.ErrorContains(t, testCheckup.Teardown(context.Background()), expectedVMIDeletionFailure.Error())
 	})
+
+	t.Run("wait for VMI deletion fails", func(t *testing.T) {
+		expectedReadFailure := errors.New("failed to read VMI")
+
+		testClient := newClientStub()
+		testClient.vmiReadFailure = expectedReadFailure
+
+		testCheckup := checkup.New(testClient, testNamespace, newTestConfig())
+
+		assert.NoError(t, testCheckup.Setup(context.Background()))
+		assert.NoError(t, testCheckup.Run(context.Background()))
+
+		assert.ErrorContains(t, testCheckup.Teardown(context.Background()), expectedReadFailure.Error())
+	})
 }
 
 type clientStub struct {

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -22,11 +22,14 @@ package checkup_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 
@@ -50,6 +53,11 @@ func TestCheckupShouldSucceed(t *testing.T) {
 	assert.NoError(t, testCheckup.Run(context.Background()))
 	assert.NoError(t, testCheckup.Teardown(context.Background()))
 
+	vmiName := testClient.VMIName()
+	assert.NotEmpty(t, vmiName)
+	_, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiName)
+	assert.ErrorContains(t, err, "not found")
+
 	actualResults := testCheckup.Results()
 	expectedResults := status.Results{}
 
@@ -68,9 +76,26 @@ func TestSetupShouldFail(t *testing.T) {
 	})
 }
 
+func TestTeardownShouldFailWhen(t *testing.T) {
+	t.Run("VMI deletion fails", func(t *testing.T) {
+		expectedVMIDeletionFailure := errors.New("failed to delete VMI")
+
+		testClient := newClientStub()
+		testClient.vmiDeletionFailure = expectedVMIDeletionFailure
+		testCheckup := checkup.New(testClient, testNamespace, newTestConfig())
+
+		assert.NoError(t, testCheckup.Setup(context.Background()))
+		assert.NoError(t, testCheckup.Run(context.Background()))
+
+		assert.ErrorContains(t, testCheckup.Teardown(context.Background()), expectedVMIDeletionFailure.Error())
+	})
+}
+
 type clientStub struct {
 	createdVMIs        map[string]*kvcorev1.VirtualMachineInstance
 	vmiCreationFailure error
+	vmiReadFailure     error
+	vmiDeletionFailure error
 }
 
 func newClientStub() *clientStub {
@@ -86,10 +111,45 @@ func (cs *clientStub) CreateVirtualMachineInstance(_ context.Context,
 		return nil, cs.vmiCreationFailure
 	}
 
-	vmiFullName := fmt.Sprintf("%s/%s", namespace, vmi.Name)
+	vmiFullName := checkup.ObjectFullName(namespace, vmi.Name)
 	cs.createdVMIs[vmiFullName] = vmi
 
 	return vmi, nil
+}
+
+func (cs *clientStub) GetVirtualMachineInstance(_ context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error) {
+	if cs.vmiReadFailure != nil {
+		return nil, cs.vmiReadFailure
+	}
+
+	vmiFullName := checkup.ObjectFullName(namespace, name)
+	vmi, exist := cs.createdVMIs[vmiFullName]
+	if !exist {
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstances"}, name)
+	}
+
+	return vmi, nil
+}
+
+func (cs *clientStub) DeleteVirtualMachineInstance(_ context.Context, namespace, name string) error {
+	if cs.vmiDeletionFailure != nil {
+		return cs.vmiDeletionFailure
+	}
+
+	vmiFullName := checkup.ObjectFullName(namespace, name)
+	delete(cs.createdVMIs, vmiFullName)
+
+	return nil
+}
+
+func (cs *clientStub) VMIName() string {
+	for vmiName := range cs.createdVMIs {
+		if strings.Contains(vmiName, checkup.VMINamePrefix) {
+			return vmiName
+		}
+	}
+
+	return ""
 }
 
 func newTestConfig() config.Config {

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -70,6 +70,22 @@ func (c *Client) CreateVirtualMachineInstance(ctx context.Context,
 	}
 }
 
+func (c *Client) GetVirtualMachineInstance(ctx context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error) {
+	resultCh := make(chan resultWrapper, 1)
+
+	go func() {
+		vmi, err := c.KubevirtClient.VirtualMachineInstance(namespace).Get(name, &metav1.GetOptions{})
+		resultCh <- resultWrapper{vmi, err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		return result.vmi, result.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 func (c *Client) DeleteVirtualMachineInstance(ctx context.Context, namespace, name string) error {
 	resultCh := make(chan error, 1)
 

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -221,7 +221,7 @@ func newKubeVirtDPDKCheckerRole() *rbacv1.Role {
 			{
 				APIGroups: []string{"kubevirt.io"},
 				Resources: []string{"virtualmachineinstances"},
-				Verbs:     []string{"create"},
+				Verbs:     []string{"create", "delete"},
 			},
 		},
 	}

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -221,7 +221,7 @@ func newKubeVirtDPDKCheckerRole() *rbacv1.Role {
 			{
 				APIGroups: []string{"kubevirt.io"},
 				Resources: []string{"virtualmachineinstances"},
-				Verbs:     []string{"create", "delete"},
+				Verbs:     []string{"create", "get", "delete"},
 			},
 		},
 	}


### PR DESCRIPTION
Delete the VirtualMachineInstance object and wait for its deletion during the teardown stage.

Manually tested against an OpenShift Virtualization 4.11 cluster.

~~Depends on PR #20.~~

Based on PR https://github.com/kiagnose/kubevirt-rt-checkup/pull/20.