### PR TITLE
config, vmi, checkup: Replace NodeSelector with affinity logic

### DIFF
--- a/pkg/internal/checkup/affinity/affinity.go
+++ b/pkg/internal/checkup/affinity/affinity.go
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package affinity
+
+import (
+	k8scorev1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/config"
+)
+
+// NewNodeAffinity returns new node affinity with node selector of the given node name.
+// Adding it to a VMI will make sure it will schedule on the given node name.
+func NewNodeAffinity(label config.Label) *k8scorev1.NodeAffinity {
+	req := k8scorev1.NodeSelectorRequirement{
+		Key:      label.Key,
+		Operator: k8scorev1.NodeSelectorOpIn,
+		Values:   []string{label.Value},
+	}
+	term := []k8scorev1.NodeSelectorTerm{
+		{
+			MatchExpressions: []k8scorev1.NodeSelectorRequirement{req},
+		},
+	}
+	return &k8scorev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &k8scorev1.NodeSelector{
+			NodeSelectorTerms: term,
+		},
+	}
+}
+
+// NewPodAntiAffinity returns new pod anti-affinity with label selector of the given label key and value.
+// Adding it to a VMI will make sure it won't schedule on the same node as other VMIs with the given label.
+func NewPodAntiAffinity(label config.Label) *k8scorev1.PodAntiAffinity {
+	req := k8smetav1.LabelSelectorRequirement{
+		Operator: k8smetav1.LabelSelectorOpIn,
+		Key:      label.Key,
+		Values:   []string{label.Value},
+	}
+	labelSelector := &k8smetav1.LabelSelector{
+		MatchExpressions: []k8smetav1.LabelSelectorRequirement{req},
+	}
+	term := k8scorev1.PodAffinityTerm{
+		TopologyKey:   k8scorev1.LabelHostname,
+		LabelSelector: labelSelector,
+	}
+	return &k8scorev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []k8scorev1.PodAffinityTerm{term},
+	}
+}

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -168,7 +168,6 @@ chpasswd:
 		vmi.WithHugePages(),
 		vmi.WithMemoryRequest("8Gi"),
 		vmi.WithTerminationGracePeriodSeconds(terminationGracePeriodSeconds),
-		vmi.WithNodeSelector(checkupConfig.DPDKNodeLabelSelector),
 		vmi.WithPVCVolume(rootDiskName, "rhel8-yummy-gorilla"),
 		vmi.WithVirtIODisk(rootDiskName),
 		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, userData),

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -168,12 +168,10 @@ func (cs *clientStub) VMIName() string {
 
 func newTestConfig() config.Config {
 	return config.Config{
-		PodName:                           testPodName,
-		PodUID:                            testPodUID,
-		NUMASocket:                        0,
-		NetworkAttachmentDefinitionName:   testNetworkAttachmentDefinitionName,
-		TrafficGeneratorNodeLabelSelector: "",
-		DPDKNodeLabelSelector:             "",
+		PodName:                         testPodName,
+		PodUID:                          testPodUID,
+		NUMASocket:                      0,
+		NetworkAttachmentDefinitionName: testNetworkAttachmentDefinitionName,
 		TrafficGeneratorPacketsPerSecondInMillions: config.TrafficGeneratorPacketsPerSecondInMillionsDefault,
 		PortBandwidthGB:                config.PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress: net.HardwareAddr{},

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -164,20 +164,6 @@ func WithTerminationGracePeriodSeconds(terminationGracePeriodSeconds int64) Opti
 	}
 }
 
-func WithNodeSelector(nodeName string) Option {
-	return func(vmi *kvcorev1.VirtualMachineInstance) {
-		if nodeName == "" {
-			return
-		}
-
-		if vmi.Spec.NodeSelector == nil {
-			vmi.Spec.NodeSelector = map[string]string{}
-		}
-
-		vmi.Spec.NodeSelector[corev1.LabelHostname] = nodeName
-	}
-}
-
 func WithMultusNetwork(name, networkAttachmentDefinitionName string) Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
 		vmi.Spec.Networks = append(vmi.Spec.Networks, kvcorev1.Network{

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -62,6 +62,18 @@ func New(name string, options ...Option) *kvcorev1.VirtualMachineInstance {
 	return newVMI
 }
 
+func WithLabels(labels map[string]string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if vmi.Labels == nil {
+			vmi.Labels = map[string]string{}
+		}
+
+		for key, val := range labels {
+			vmi.Labels[key] = val
+		}
+	}
+}
+
 func WithoutCRIOCPULoadBalancing() Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
 		if vmi.ObjectMeta.Annotations == nil {
@@ -206,6 +218,15 @@ func WithCloudInitNoCloudVolume(name, userData string) Option {
 		}
 
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newVolume)
+	}
+}
+
+// WithAffinity adds the given affinity.
+func WithAffinity(affinity *corev1.Affinity) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if affinity != nil {
+			vmi.Spec.Affinity = affinity
+		}
 	}
 }
 

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -38,9 +38,9 @@ const (
 	numaSocket                                 = 1
 	networkAttachmentDefinitionName            = "intel-dpdk-network1"
 	portBandwidthGB                            = 100
-	trafficGeneratorNodeLabelSelector          = "node-role.kubernetes.io/worker-dpdk1"
+	trafficGeneratorNodeLabelSelector          = "node-role.kubernetes.io/worker-dpdk1=''"
 	trafficGeneratorPacketsPerSecondInMillions = 6
-	dpdkNodeLabelSelector                      = "node-role.kubernetes.io/worker-dpdk2"
+	dpdkNodeLabelSelector                      = "node-role.kubernetes.io/worker-dpdk2="
 	trafficGeneratorEastMacAddress             = "DE:AD:BE:EF:00:01"
 	trafficGeneratorWestMacAddress             = "DE:AD:BE:EF:01:00"
 	dpdkEastMacAddress                         = "DE:AD:BE:EF:00:02"
@@ -95,6 +95,8 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 	trafficGeneratorWestHWAddress, _ := net.ParseMAC(trafficGeneratorWestMacAddress)
 	dpdkEastHWAddress, _ := net.ParseMAC(dpdkEastMacAddress)
 	dpdkWestHWAddress, _ := net.ParseMAC(dpdkWestMacAddress)
+	trafficGeneratorNodeLabelSelectorLabel, _ := config.ParseLabel(trafficGeneratorNodeLabelSelector)
+	dpdkNodeLabelSelectorLabel, _ := config.ParseLabel(dpdkNodeLabelSelector)
 	expectedConfig := config.Config{
 		PodName:                         testPodName,
 		PodUID:                          testPodUID,
@@ -102,8 +104,8 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 		PortBandwidthGB:                 portBandwidthGB,
 		NetworkAttachmentDefinitionName: networkAttachmentDefinitionName,
 		TrafficGeneratorPacketsPerSecondInMillions: trafficGeneratorPacketsPerSecondInMillions,
-		TrafficGeneratorNodeLabelSelector:          trafficGeneratorNodeLabelSelector,
-		DPDKNodeLabelSelector:                      dpdkNodeLabelSelector,
+		TrafficGeneratorNodeLabelSelector:          trafficGeneratorNodeLabelSelectorLabel,
+		DPDKNodeLabelSelector:                      dpdkNodeLabelSelectorLabel,
 		TrafficGeneratorEastMacAddress:             trafficGeneratorEastHWAddress,
 		TrafficGeneratorWestMacAddress:             trafficGeneratorWestHWAddress,
 		DPDKEastMacAddress:                         dpdkEastHWAddress,
@@ -139,6 +141,18 @@ func TestNewShouldFailWhen(t *testing.T) {
 			key:            config.NetworkAttachmentDefinitionNameParamName,
 			faultyKeyValue: "",
 			expectedError:  config.ErrInvalidNetworkAttachmentDefinitionName,
+		},
+		{
+			description:    "TrafficGeneratorNodeLabelSelector is invalid",
+			key:            config.TrafficGeneratorNodeLabelSelectorParamName,
+			faultyKeyValue: "wrong:format",
+			expectedError:  config.ErrInvalidTrafficGeneratorNodeLabelSelector,
+		},
+		{
+			description:    "DPDKNodeLabelSelector is invalid",
+			key:            config.DPDKNodeLabelSelectorParamName,
+			faultyKeyValue: "invalid-format",
+			expectedError:  config.ErrInvalidDPDKNodeLabelSelector,
 		},
 		{
 			description:    "TrafficGeneratorPacketsPerSecondInMillions is invalid",


### PR DESCRIPTION
Currently the vmi is set so a specific node by name.
Changing to use affinity with label logic: 
- label selectors trafficGeneratorNodeLabelSelector and DPDKNodeLabelSelector are changed to key=value labels.
- affinity and label options are added to the vmi package
-  {DPDK-vmi,trex-pod} gets a default label "app={dpdk,trex}"
- if DPDKNodeLabelSelector is not set, then the  default label of the other object would be used as an anti affinity. 