### PR TITLE
checkup, pod: Mount libmodules

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -274,6 +274,7 @@ func newTrafficGeneratorPod(checkupConfig config.Config, secondaryNetworkRequest
 		pod.WithContainerCPUsStrict(TrexPodNumCPUs),
 		pod.WithContainerHugepagesResources(TrexPodNumHugepages),
 		pod.WithContainerHugepagesVolumeMount(),
+		pod.WithContainerLibModulesVolumeMount(),
 	)
 
 	return pod.NewPod(randomizeName(TrexPodNamePrefix),
@@ -285,6 +286,7 @@ func newTrafficGeneratorPod(checkupConfig config.Config, secondaryNetworkRequest
 		pod.WithNodeSelector(checkupConfig.TrafficGeneratorNodeLabelSelector),
 		pod.WithNetworkRequestAnnotation(secondaryNetworkRequest),
 		pod.WithHugepagesVolume(),
+		pod.WithLibModulesVolume(),
 	)
 }
 

--- a/pkg/internal/checkup/pod/container.go
+++ b/pkg/internal/checkup/pod/container.go
@@ -107,6 +107,16 @@ func WithContainerHugepagesVolumeMount() ContainerOption {
 	}
 }
 
+func WithContainerLibModulesVolumeMount() ContainerOption {
+	return func(container *corev1.Container) {
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      "modules",
+			MountPath: "/lib/modules",
+			ReadOnly:  true,
+		})
+	}
+}
+
 func NewSecurityContext(user int64, allowPrivilegeEscalation bool, addCapabilities []corev1.Capability) *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		AllowPrivilegeEscalation: pointer(allowPrivilegeEscalation),

--- a/pkg/internal/checkup/pod/pod_test.go
+++ b/pkg/internal/checkup/pod/pod_test.go
@@ -123,6 +123,26 @@ func TestNewPodWithHugepagesVolume(t *testing.T) {
 	assert.Equal(t, expectedPod, actualPod)
 }
 
+func TestNewPodWithLibModulesVolume(t *testing.T) {
+	actualPod := pod.NewPod(testPodName, pod.WithLibModulesVolume())
+
+	directoryHostPath := k8scorev1.HostPathDirectory
+	expectedPod := newBasePod(actualPod.Name)
+	expectedPod.Spec.Volumes = []k8scorev1.Volume{
+		{
+			Name: "modules",
+			VolumeSource: k8scorev1.VolumeSource{
+				HostPath: &k8scorev1.HostPathVolumeSource{
+					Path: "/lib/modules",
+					Type: &directoryHostPath,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expectedPod, actualPod)
+}
+
 func TestNewPodWithoutCRIOCPULoadBalancing(t *testing.T) {
 	actualPod := pod.NewPod(testPodName, pod.WithoutCRIOCPULoadBalancing())
 
@@ -185,6 +205,13 @@ func newContainer(name string) k8scorev1.Container {
 		Image:           pod.ContainerDiskImage,
 		ImagePullPolicy: k8scorev1.PullAlways,
 		Command:         []string{"/bin/bash", "-c", "sleep INF"},
+		VolumeMounts: []k8scorev1.VolumeMount{
+			{
+				Name:      "modules",
+				MountPath: "/lib/modules",
+				ReadOnly:  true,
+			},
+		},
 		SecurityContext: &k8scorev1.SecurityContext{
 			AllowPrivilegeEscalation: &falseBool,
 			Capabilities: &k8scorev1.Capabilities{

--- a/pkg/internal/checkup/pod/spec.go
+++ b/pkg/internal/checkup/pod/spec.go
@@ -100,6 +100,21 @@ func WithHugepagesVolume() PodOption {
 	}
 }
 
+func WithLibModulesVolume() PodOption {
+	return func(pod *corev1.Pod) {
+		pod.Spec.Volumes = append(pod.Spec.Volumes,
+			corev1.Volume{
+				Name: "modules",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/lib/modules",
+						Type: pointer(corev1.HostPathDirectory),
+					},
+				},
+			})
+	}
+}
+
 func WithoutCRIOCPULoadBalancing() PodOption {
 	return func(pod *corev1.Pod) {
 		if pod.ObjectMeta.Annotations == nil {


### PR DESCRIPTION
TRex application needs access to the kernel modules to work properly.
 Mounting libmodules to the traffic generator pod.