### PR TITLE
mainflow, printConfig(): Log int values as string

### DIFF
--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -60,14 +60,14 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 func printConfig(checkupConfig config.Config) {
 	log.Println("Using the following config:")
-	log.Printf("\t%q: %q", config.NUMASocketParamName, checkupConfig.NUMASocket)
-	log.Printf("\t%q: %q", config.NetworkAttachmentDefinitionNameParamName, checkupConfig.NetworkAttachmentDefinitionName)
-	log.Printf("\t%q: %q", config.PortBandwidthGBParamName, checkupConfig.PortBandwidthGB)
-	log.Printf("\t%q: %q", config.TrafficGeneratorNodeLabelSelectorParamName, checkupConfig.TrafficGeneratorNodeLabelSelector)
-	log.Printf("\t%q: %q", config.TrafficGeneratorPacketsPerSecondInMillionsParamName,
+	log.Printf("%q: %q", config.NUMASocketParamName, checkupConfig.NUMASocket)
+	log.Printf("%q: %q", config.NetworkAttachmentDefinitionNameParamName, checkupConfig.NetworkAttachmentDefinitionName)
+	log.Printf("%q: %q", config.PortBandwidthGBParamName, checkupConfig.PortBandwidthGB)
+	log.Printf("%q: %q", config.TrafficGeneratorNodeLabelSelectorParamName, checkupConfig.TrafficGeneratorNodeLabelSelector)
+	log.Printf("%q: %q", config.TrafficGeneratorPacketsPerSecondInMillionsParamName,
 		checkupConfig.TrafficGeneratorPacketsPerSecondInMillions)
-	log.Printf("\t%q: %q", config.DPDKNodeLabelSelectorParamName, checkupConfig.DPDKNodeLabelSelector)
-	log.Printf("\t%q: %q", config.TrafficGeneratorEastMacAddressParamName, checkupConfig.TrafficGeneratorEastMacAddress)
-	log.Printf("\t%q: %q", config.DPDKEastMacAddressParamName, checkupConfig.DPDKEastMacAddress)
-	log.Printf("\t%q: %q", config.TestDurationParamName, checkupConfig.TestDuration)
+	log.Printf("%q: %q", config.DPDKNodeLabelSelectorParamName, checkupConfig.DPDKNodeLabelSelector)
+	log.Printf("%q: %q", config.TrafficGeneratorEastMacAddressParamName, checkupConfig.TrafficGeneratorEastMacAddress)
+	log.Printf("%q: %q", config.DPDKEastMacAddressParamName, checkupConfig.DPDKEastMacAddress)
+	log.Printf("%q: %q", config.TestDurationParamName, checkupConfig.TestDuration)
 }

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -21,6 +21,7 @@ package pkg
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	kconfig "github.com/kiagnose/kiagnose/kiagnose/config"
@@ -60,12 +61,12 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 func printConfig(checkupConfig config.Config) {
 	log.Println("Using the following config:")
-	log.Printf("%q: %q", config.NUMASocketParamName, checkupConfig.NUMASocket)
+	log.Printf("%q: %q", config.NUMASocketParamName, fmt.Sprintf("%d", checkupConfig.NUMASocket))
 	log.Printf("%q: %q", config.NetworkAttachmentDefinitionNameParamName, checkupConfig.NetworkAttachmentDefinitionName)
-	log.Printf("%q: %q", config.PortBandwidthGBParamName, checkupConfig.PortBandwidthGB)
+	log.Printf("%q: %q", config.PortBandwidthGBParamName, fmt.Sprintf("%d", checkupConfig.PortBandwidthGB))
 	log.Printf("%q: %q", config.TrafficGeneratorNodeLabelSelectorParamName, checkupConfig.TrafficGeneratorNodeLabelSelector)
 	log.Printf("%q: %q", config.TrafficGeneratorPacketsPerSecondInMillionsParamName,
-		checkupConfig.TrafficGeneratorPacketsPerSecondInMillions)
+		fmt.Sprintf("%d", checkupConfig.TrafficGeneratorPacketsPerSecondInMillions))
 	log.Printf("%q: %q", config.DPDKNodeLabelSelectorParamName, checkupConfig.DPDKNodeLabelSelector)
 	log.Printf("%q: %q", config.TrafficGeneratorEastMacAddressParamName, checkupConfig.TrafficGeneratorEastMacAddress)
 	log.Printf("%q: %q", config.DPDKEastMacAddressParamName, checkupConfig.DPDKEastMacAddress)


### PR DESCRIPTION
Currently, the int values are not logged correctly.
Add a conversion to fix it.

Signed-off-by: Orel Misan <omisan@redhat.com>

Manually tested against an OpenShift Virtualization 4.12 cluster.