### PR TITLE
checkup: Rename Trex to TrafficGenerator

### DIFF
--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -295,7 +295,7 @@ func (cs *clientStub) GetPod(_ context.Context, namespace, name string) (*k8scor
 
 func (cs *clientStub) TrafficGeneratorPodName() string {
 	for _, pod := range cs.createdPods {
-		if strings.Contains(pod.Name, checkup.TrexPodNamePrefix) {
+		if strings.Contains(pod.Name, checkup.TrafficGeneratorPodNamePrefix) {
 			return pod.Name
 		}
 	}


### PR DESCRIPTION
Trex is an implementation detail, hide it for external usage.

Manually tested against an OpenShift Virtualization 4.12 cluster.

Signed-off-by: Orel Misan <omisan@redhat.com>