### PR TITLE
checkup: Generate cloud-init data

### DIFF
--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -182,6 +182,17 @@ func TestTeardownShouldFailWhen(t *testing.T) {
 	}
 }
 
+func TestCloudInitString(t *testing.T) {
+	actualString := checkup.CloudInit("user", "password")
+	expectedString := `#cloud-config
+user: user
+password: password
+chpasswd:
+  expire: false`
+
+	assert.Equal(t, expectedString, actualString)
+}
+
 type clientStub struct {
 	createdVMIs        map[string]*kvcorev1.VirtualMachineInstance
 	createdPods        map[string]*k8scorev1.Pod


### PR DESCRIPTION
Currently, the cloud-init data is hard-coded.
Generate the cloud-init using a function, in order to be able to share the credentials with the component that will log in to the VMI in a follow-up commit.

Signed-off-by: Orel Misan <omisan@redhat.com>