### PR TITLE
executor: Run testpmd

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -71,11 +71,6 @@ const (
 	TrafficGeneratorPodNamePrefix = "kubevirt-dpdk-checkup-traffic-gen"
 )
 
-const (
-	VMIUsername = "cloud-user"
-	VMIPassword = "0tli-pxem-xknu" // #nosec
-)
-
 func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config, executor testExecutor) *Checkup {
 	return &Checkup{
 		client:    client,
@@ -254,7 +249,7 @@ func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 		vmi.WithNodeSelector(checkupConfig.DPDKNodeLabelSelector),
 		vmi.WithPVCVolume(rootDiskName, "rhel8-yummy-gorilla"),
 		vmi.WithVirtIODisk(rootDiskName),
-		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(VMIUsername, VMIPassword)),
+		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword)),
 		vmi.WithVirtIODisk(cloudInitDiskName),
 	)
 }

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -224,9 +224,7 @@ func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 		rootDiskName      = "rootdisk"
 		cloudInitDiskName = "cloudinitdisk"
 		eastNetworkName   = "nic-east"
-		eastNICPCIAddress = "0000:06:00.0"
 		westNetworkName   = "nic-west"
-		westNICPCIAddress = "0000:07:00.0"
 
 		terminationGracePeriodSeconds = 0
 	)
@@ -237,9 +235,9 @@ func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 		vmi.WithoutCRIOCPUQuota(),
 		vmi.WithoutCRIOIRQLoadBalancing(),
 		vmi.WithDedicatedCPU(CPUSocketsCount, CPUCoresCount, CPUTreadsCount),
-		vmi.WithSRIOVInterface(eastNetworkName, checkupConfig.DPDKEastMacAddress.String(), eastNICPCIAddress),
+		vmi.WithSRIOVInterface(eastNetworkName, checkupConfig.DPDKEastMacAddress.String(), config.VMIEastNICPCIAddress),
 		vmi.WithMultusNetwork(eastNetworkName, checkupConfig.NetworkAttachmentDefinitionName),
-		vmi.WithSRIOVInterface(westNetworkName, checkupConfig.DPDKWestMacAddress.String(), westNICPCIAddress),
+		vmi.WithSRIOVInterface(westNetworkName, checkupConfig.DPDKWestMacAddress.String(), config.VMIWestNICPCIAddress),
 		vmi.WithMultusNetwork(westNetworkName, checkupConfig.NetworkAttachmentDefinitionName),
 		vmi.WithNetworkInterfaceMultiQueue(),
 		vmi.WithRandomNumberGenerator(),

--- a/pkg/internal/checkup/console/console.go
+++ b/pkg/internal/checkup/console/console.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"regexp"
+	"strings"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -81,6 +83,80 @@ func NewExpecter(serialConsoleClient vmiSerialConsoleClient,
 
 func RetValue(retcode string) string {
 	return "\n" + retcode + CRLF + ".*" + PromptExpression
+}
+
+// SafeExpectBatchWithResponse runs the batch from `expected`, connecting to a VMI's console and
+// waiting for the batch to return with a response until timeout.
+// It validates that the commands arrive to the console.
+// NOTE: This functions inherits limitations from `ExpectBatchWithValidatedSend`, refer to it for more information.
+func SafeExpectBatchWithResponse(serialConsoleClient vmiSerialConsoleClient,
+	vmiNamespace,
+	vmiName string,
+	expected []expect.Batcher,
+	timeout time.Duration) ([]expect.BatchRes, error) {
+	expecter, _, err := NewExpecter(serialConsoleClient, vmiNamespace, vmiName, timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer expecter.Close()
+
+	resp, err := ExpectBatchWithValidatedSend(expecter, expected, timeout)
+	if err != nil {
+		log.Printf("%v", resp)
+	}
+	return resp, err
+}
+
+// ExpectBatchWithValidatedSend adds the expect.BSnd command to the exect.BExp expression.
+// It is done to make sure the match was found in the result of the expect.BSnd
+// command and not in a leftover that wasn't removed from the buffer.
+// NOTE: the method contains the following limitations:
+//   - Use of `BatchSwitchCase`
+//   - Multiline commands
+//   - No more than one sequential send or receive
+func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batcher, timeout time.Duration) ([]expect.BatchRes, error) {
+	sendFlag := false
+	expectFlag := false
+	previousSend := ""
+
+	const minimumRequiredBatches = 2
+	if len(batch) < minimumRequiredBatches {
+		return nil, fmt.Errorf("ExpectBatchWithValidatedSend requires at least 2 batchers, supplied %v", batch)
+	}
+
+	for i, batcher := range batch {
+		switch batcher.Cmd() {
+		case expect.BatchExpect:
+			if expectFlag {
+				return nil, fmt.Errorf("two sequential expect.BExp are not allowed")
+			}
+			expectFlag = true
+			sendFlag = false
+			if _, ok := batch[i].(*expect.BExp); !ok {
+				return nil, fmt.Errorf("ExpectBatchWithValidatedSend support only expect of type BExp")
+			}
+			bExp, _ := batch[i].(*expect.BExp)
+			previousSend = regexp.QuoteMeta(previousSend)
+
+			// Remove the \n since it is translated by the console to \r\n.
+			previousSend = strings.TrimSuffix(previousSend, "\n")
+			bExp.R = fmt.Sprintf("%s%s%s", previousSend, "((?s).*)", bExp.R)
+		case expect.BatchSend:
+			if sendFlag {
+				return nil, fmt.Errorf("two sequential expect.BSend are not allowed")
+			}
+			sendFlag = true
+			expectFlag = false
+			previousSend = batcher.Arg()
+		case expect.BatchSwitchCase:
+			return nil, fmt.Errorf("ExpectBatchWithValidatedSend doesn't support BatchSwitchCase")
+		default:
+			return nil, fmt.Errorf("unknown command: ExpectBatchWithValidatedSend supports only BatchExpect and BatchSend")
+		}
+	}
+
+	res, err := expecter.ExpectBatch(batch, timeout)
+	return res, err
 }
 
 func configureConsole(expecter expect.Expecter, shouldSudo bool) error {

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -22,7 +22,11 @@ package executor
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 	"time"
+
+	expect "github.com/google/goexpect"
 
 	"kubevirt.io/client-go/kubecli"
 
@@ -64,5 +68,59 @@ func (e Executor) Execute(ctx context.Context, vmiName string) (status.Results, 
 		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, vmiName, err)
 	}
 
+	log.Printf("Starting testpmd in VMI...")
+	if err := e.runTestpmd(vmiName); err != nil {
+		return status.Results{}, err
+	}
+
 	return status.Results{}, nil
+}
+
+func (e Executor) runTestpmd(vmiName string) error {
+	const batchTimeout = 30 * time.Second
+
+	const testpmdPromt = "testpmd> "
+
+	testpmdCmd := buildTestpmdCmd(e.vmiEastNICPCIAddress, e.vmiWestNICPCIAddress, e.vmiEastMACAddress, e.vmiWestMACAddress)
+
+	resp, err := console.SafeExpectBatchWithResponse(e.client, e.namespace, vmiName,
+		[]expect.Batcher{
+			&expect.BSnd{S: testpmdCmd + "\n"},
+			&expect.BExp{R: testpmdPromt},
+			&expect.BSnd{S: "start" + "\n"},
+			&expect.BExp{R: testpmdPromt},
+		},
+		batchTimeout,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("%v", resp)
+
+	return nil
+}
+
+func buildTestpmdCmd(vmiEastNICPCIAddress, vmiWestNICPCIAddress, vmiEastMACAddress, vmiWestMACAddress string) string {
+	const (
+		cpuList       = "0-7"
+		numberOfCores = 7
+	)
+
+	sb := strings.Builder{}
+	sb.WriteString("dpdk-testpmd ")
+	sb.WriteString(fmt.Sprintf("-l %s ", cpuList))
+	sb.WriteString(fmt.Sprintf("-a %s ", vmiEastNICPCIAddress))
+	sb.WriteString(fmt.Sprintf("-a %s ", vmiWestNICPCIAddress))
+	sb.WriteString("-- ")
+	sb.WriteString("-i ")
+	sb.WriteString(fmt.Sprintf("--nb-cores=%d ", numberOfCores))
+	sb.WriteString("--rxd=2048 ")
+	sb.WriteString("--txd=2048 ")
+	sb.WriteString("--forward-mode=mac ")
+	sb.WriteString(fmt.Sprintf("--eth-peer=0,%s ", vmiEastMACAddress))
+	sb.WriteString(fmt.Sprintf("--eth-peer=1,%s", vmiWestMACAddress))
+
+	return sb.String()
 }

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -27,6 +27,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/console"
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/config"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/status"
 )
 
@@ -35,18 +36,26 @@ type vmiSerialConsoleClient interface {
 }
 
 type Executor struct {
-	client      vmiSerialConsoleClient
-	namespace   string
-	vmiUsername string
-	vmiPassword string
+	client               vmiSerialConsoleClient
+	namespace            string
+	vmiUsername          string
+	vmiPassword          string
+	vmiEastNICPCIAddress string
+	vmiEastMACAddress    string
+	vmiWestNICPCIAddress string
+	vmiWestMACAddress    string
 }
 
-func New(client vmiSerialConsoleClient, namespace, vmiUsername, vmiPassword string) Executor {
+func New(client vmiSerialConsoleClient, namespace string, cfg config.Config) Executor {
 	return Executor{
-		client:      client,
-		namespace:   namespace,
-		vmiUsername: vmiUsername,
-		vmiPassword: vmiPassword,
+		client:               client,
+		namespace:            namespace,
+		vmiUsername:          config.VMIUsername,
+		vmiPassword:          config.VMIPassword,
+		vmiEastNICPCIAddress: config.VMIEastNICPCIAddress,
+		vmiEastMACAddress:    cfg.DPDKEastMacAddress.String(),
+		vmiWestNICPCIAddress: config.VMIWestNICPCIAddress,
+		vmiWestMACAddress:    cfg.DPDKWestMacAddress.String(),
 	}
 }
 

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -55,6 +55,11 @@ const (
 	TestDurationDefault                               = 5 * time.Minute
 )
 
+const (
+	VMIUsername = "cloud-user"
+	VMIPassword = "0tli-pxem-xknu" // #nosec
+)
+
 var (
 	ErrInvalidNUMASocket                                 = errors.New("invalid NUMA Socket")
 	ErrInvalidNetworkAttachmentDefinitionName            = errors.New("invalid Network-Attachment-Definition Name")

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -58,6 +58,9 @@ const (
 const (
 	VMIUsername = "cloud-user"
 	VMIPassword = "0tli-pxem-xknu" // #nosec
+
+	VMIEastNICPCIAddress = "0000:06:00.0"
+	VMIWestNICPCIAddress = "0000:07:00.0"
 )
 
 var (

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -52,7 +52,7 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 	printConfig(cfg)
 
-	dpdkCheckupExecutor := executor.New(c, namespace, checkup.VMIUsername, checkup.VMIPassword)
+	dpdkCheckupExecutor := executor.New(c, namespace, config.VMIUsername, config.VMIPassword)
 	l := launcher.New(
 		checkup.New(c, namespace, cfg, dpdkCheckupExecutor),
 		reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName),

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -52,7 +52,7 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 	printConfig(cfg)
 
-	dpdkCheckupExecutor := executor.New(c, namespace, config.VMIUsername, config.VMIPassword)
+	dpdkCheckupExecutor := executor.New(c, namespace, cfg)
 	l := launcher.New(
 		checkup.New(c, namespace, cfg, dpdkCheckupExecutor),
 		reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName),


### PR DESCRIPTION
1. Build the testpmd command line arguments.
2. Wait for it to successfully initialize.
3. Start it.

Manually tested against an OpenShift Virtualization 4.12 cluster.