### PR TITLE
checkup: Minor refactor

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -262,6 +262,22 @@ func (c *Checkup) waitForPodRunningStatus(ctx context.Context, namespace, name s
 	return updatedPod, nil
 }
 
+func (c *Checkup) deletePod(ctx context.Context) error {
+	if c.trafficGeneratorPod == nil {
+		return fmt.Errorf("failed to delete traffic generator Pod, object doesn't exist")
+	}
+
+	vmiFullName := ObjectFullName(c.trafficGeneratorPod.Namespace, c.trafficGeneratorPod.Name)
+
+	log.Printf("Trying to delete traffic generator Pod: %q", vmiFullName)
+	if err := c.client.DeletePod(ctx, c.trafficGeneratorPod.Namespace, c.trafficGeneratorPod.Name); err != nil {
+		log.Printf("Failed to delete traffic generator Pod: %q", vmiFullName)
+		return err
+	}
+
+	return nil
+}
+
 func ObjectFullName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
@@ -384,22 +400,6 @@ func (c *Checkup) waitForPodDeletion(ctx context.Context) error {
 	}
 
 	log.Printf("Pod %q is deleted", podFullName)
-	return nil
-}
-
-func (c *Checkup) deletePod(ctx context.Context) error {
-	if c.trafficGeneratorPod == nil {
-		return fmt.Errorf("failed to delete traffic generator Pod, object doesn't exist")
-	}
-
-	vmiFullName := ObjectFullName(c.trafficGeneratorPod.Namespace, c.trafficGeneratorPod.Name)
-
-	log.Printf("Trying to delete traffic generator Pod: %q", vmiFullName)
-	if err := c.client.DeletePod(ctx, c.trafficGeneratorPod.Namespace, c.trafficGeneratorPod.Name); err != nil {
-		log.Printf("Failed to delete traffic generator Pod: %q", vmiFullName)
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -303,6 +303,12 @@ func ObjectFullName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
+func randomizeName(prefix string) string {
+	const randomStringLen = 5
+
+	return fmt.Sprintf("%s-%s", prefix, k8srand.String(randomStringLen))
+}
+
 func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 	const (
 		CPUSocketsCount   = 1
@@ -337,12 +343,6 @@ func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword)),
 		vmi.WithVirtIODisk(cloudInitDiskName),
 	)
-}
-
-func randomizeName(prefix string) string {
-	const randomStringLen = 5
-
-	return fmt.Sprintf("%s-%s", prefix, k8srand.String(randomStringLen))
 }
 
 func newTrafficGeneratorPod(checkupConfig config.Config, secondaryNetworkRequest string) *k8scorev1.Pod {

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -303,6 +303,17 @@ func ObjectFullName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
+func CloudInit(username, password string) string {
+	sb := strings.Builder{}
+	sb.WriteString("#cloud-config\n")
+	sb.WriteString(fmt.Sprintf("user: %s\n", username))
+	sb.WriteString(fmt.Sprintf("password: %s\n", password))
+	sb.WriteString("chpasswd:\n")
+	sb.WriteString("  expire: false")
+
+	return sb.String()
+}
+
 func randomizeName(prefix string) string {
 	const randomStringLen = 5
 
@@ -401,15 +412,4 @@ func newTrafficGeneratorPod(checkupConfig config.Config, secondaryNetworkRequest
 		pod.WithLibModulesVolume(),
 		pod.WithTerminationGracePeriodSeconds(terminationGracePeriodSeconds),
 	)
-}
-
-func CloudInit(username, password string) string {
-	sb := strings.Builder{}
-	sb.WriteString("#cloud-config\n")
-	sb.WriteString(fmt.Sprintf("user: %s\n", username))
-	sb.WriteString(fmt.Sprintf("password: %s\n", password))
-	sb.WriteString("chpasswd:\n")
-	sb.WriteString("  expire: false")
-
-	return sb.String()
 }

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -85,11 +85,9 @@ func (c *Checkup) Setup(ctx context.Context) error {
 	const errMessagePrefix = "setup"
 	var err error
 
-	createdVMI, err := c.client.CreateVirtualMachineInstance(ctx, c.namespace, c.vmi)
-	if err != nil {
-		return err
+	if err = c.createVMI(ctx); err != nil {
+		return fmt.Errorf("%s: %w", errMessagePrefix, err)
 	}
-	c.vmi = createdVMI
 
 	c.trafficGeneratorPod, err = c.createTrafficGeneratorPod(ctx)
 	if err != nil {
@@ -145,6 +143,18 @@ func (c *Checkup) Teardown(ctx context.Context) error {
 
 func (c *Checkup) Results() status.Results {
 	return c.results
+}
+
+func (c *Checkup) createVMI(ctx context.Context) error {
+	log.Printf("Creating VMI %q...", ObjectFullName(c.namespace, c.vmi.Name))
+
+	var err error
+	c.vmi, err = c.client.CreateVirtualMachineInstance(ctx, c.namespace, c.vmi)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Checkup) waitForVMIToBoot(ctx context.Context) error {


### PR DESCRIPTION
Minor refactoring of the `checkup.go` file:
1. Put all Pod's non-exported methods under the VMI's non-exported methods.
2. Put all exported helper functions after them.
3. Put all non-exported helper functions after them.

Add a log entry when creating a VMI.

Manually tested against an OpenShift Virtualization 4.12 cluster.