### PR TITLE
checkup, executor: Use a single const for testpmdPrompt

### DIFF
--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -57,6 +57,8 @@ type Executor struct {
 	trafficGeneratorPacketsPerSecondInMillions int
 }
 
+const testpmdPrompt = "testpmd> "
+
 func New(client vmiSerialConsoleClient, podClient podExecuteClient, namespace string, cfg config.Config) Executor {
 	return Executor{
 		client:               client,
@@ -110,16 +112,14 @@ func (e Executor) Execute(ctx context.Context, vmiName, podName, podContainerNam
 func (e Executor) runTestpmd(vmiName string) error {
 	const batchTimeout = 30 * time.Second
 
-	const testpmdPromt = "testpmd> "
-
 	testpmdCmd := buildTestpmdCmd(e.vmiEastNICPCIAddress, e.vmiWestNICPCIAddress, e.vmiEastMACAddress, e.vmiWestMACAddress)
 
 	resp, err := console.SafeExpectBatchWithResponse(e.client, e.namespace, vmiName,
 		[]expect.Batcher{
 			&expect.BSnd{S: testpmdCmd + "\n"},
-			&expect.BExp{R: testpmdPromt},
+			&expect.BExp{R: testpmdPrompt},
 			&expect.BSnd{S: "start" + "\n"},
-			&expect.BExp{R: testpmdPromt},
+			&expect.BExp{R: testpmdPrompt},
 		},
 		batchTimeout,
 	)
@@ -136,14 +136,12 @@ func (e Executor) runTestpmd(vmiName string) error {
 func (e Executor) clearStatsTestpmd(vmiName string) error {
 	const batchTimeout = 30 * time.Second
 
-	const testpmdPromt = "testpmd> "
-
 	const testpmdCmd = "clear fwd stats all"
 
 	_, err := console.SafeExpectBatchWithResponse(e.client, e.namespace, vmiName,
 		[]expect.Batcher{
 			&expect.BSnd{S: testpmdCmd + "\n"},
-			&expect.BExp{R: testpmdPromt},
+			&expect.BExp{R: testpmdPrompt},
 		},
 		batchTimeout,
 	)


### PR DESCRIPTION
Currently, two methods are using a local const named "testpmdPromt", with the same value.

Increase its scope, and use it from both methods.
Also fix the typo.

Signed-off-by: Orel Misan <omisan@redhat.com>

Manually tested against an OpenShift Virtualization 4.12 cluster.