### PR TITLE
checkup, results: Update test params

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -114,6 +114,8 @@ func (c *Checkup) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	c.results.TrafficGeneratorNode = c.trafficGeneratorPod.Spec.NodeName
+	c.results.DPDKVMNode = c.vmi.Status.NodeName
 
 	if c.results.TrafficGeneratorMaxDropRate != 0 {
 		return fmt.Errorf("detected %f Bps Drop Rate on the traffic generator's side", c.results.TrafficGeneratorMaxDropRate)

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -115,6 +115,22 @@ func (c *Checkup) Run(ctx context.Context) error {
 		return err
 	}
 
+	if c.results.TrafficGeneratorMaxDropRate != 0 {
+		return fmt.Errorf("detected %f Bps Drop Rate on the traffic generator's side", c.results.TrafficGeneratorMaxDropRate)
+	}
+
+	if c.results.TrafficGeneratorOutErrorPackets != 0 {
+		return fmt.Errorf("detected %d Output Error Packets on the traffic generator's side", c.results.TrafficGeneratorOutErrorPackets)
+	}
+
+	if c.results.DPDKPacketsRxDropped != 0 {
+		return fmt.Errorf("detected %d Rx packets dropped on the DPDK VM's side", c.results.DPDKPacketsRxDropped)
+	}
+
+	if c.results.DPDKPacketsTxDropped != 0 {
+		return fmt.Errorf("detected %d Tx packets dropped on the DPDK VM's side", c.results.DPDKPacketsTxDropped)
+	}
+
 	return nil
 }
 

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -63,7 +63,7 @@ func formatResults(checkupStatus status.Status) map[string]string {
 	}
 
 	formattedResults := map[string]string{
-		DropRateKey:             fmt.Sprintf("%d", checkupStatus.Results.DropRate),
+		DropRateKey:             fmt.Sprintf("%f", checkupStatus.Results.TrafficGeneratorMaxDropRate),
 		TrafficGeneratorNodeKey: checkupStatus.Results.TrafficGeneratorNode,
 		DPDKVMNodeKey:           checkupStatus.Results.DPDKVMNode,
 	}

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -30,9 +30,12 @@ import (
 )
 
 const (
-	DropRateKey             = "dropRate"
-	TrafficGeneratorNodeKey = "trafficGeneratorNode"
-	DPDKVMNodeKey           = "DPDKVMNodeKey"
+	TrafficGeneratorMaxDropRateKey     = "trafficGeneratorMaxDropRate"
+	TrafficGeneratorOutErrorPacketsKey = "trafficGeneratorOutputErrorPackets"
+	DPDKRxDropsKey                     = "DPDKRxPacketDrops"
+	DPDKTxDropsKey                     = "DPDKTxPacketDrops"
+	TrafficGeneratorNodeKey            = "trafficGeneratorNode"
+	DPDKVMNodeKey                      = "DPDKVMNodeKey"
 )
 
 type Reporter struct {
@@ -63,9 +66,12 @@ func formatResults(checkupStatus status.Status) map[string]string {
 	}
 
 	formattedResults := map[string]string{
-		DropRateKey:             fmt.Sprintf("%f", checkupStatus.Results.TrafficGeneratorMaxDropRate),
-		TrafficGeneratorNodeKey: checkupStatus.Results.TrafficGeneratorNode,
-		DPDKVMNodeKey:           checkupStatus.Results.DPDKVMNode,
+		TrafficGeneratorMaxDropRateKey:     fmt.Sprintf("%f", checkupStatus.Results.TrafficGeneratorMaxDropRate),
+		TrafficGeneratorOutErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
+		DPDKRxDropsKey:                     fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
+		DPDKTxDropsKey:                     fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
+		TrafficGeneratorNodeKey:            checkupStatus.Results.TrafficGeneratorNode,
+		DPDKVMNodeKey:                      checkupStatus.Results.DPDKVMNode,
 	}
 
 	return formattedResults

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -52,9 +52,12 @@ func TestReportShouldSucceed(t *testing.T) {
 
 func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 	const (
-		expectedDropRate             = 0
-		expectedDPDKVMNode           = "dpdk-node01"
-		expectedTrafficGeneratorNode = "dpdk-node02"
+		expectedTrafficGeneratorMaxDropRate     = 0
+		expectedTrafficGeneratorOutErrorPackets = 0
+		expectedDPDKPacketsRxDropped            = 0
+		expectedDPDKPacketsTxDropped            = 0
+		expectedDPDKVMNode                      = "dpdk-node01"
+		expectedTrafficGeneratorNode            = "dpdk-node02"
 	)
 
 	const (
@@ -73,21 +76,27 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		checkupStatus.FailureReason = []string{}
 		checkupStatus.CompletionTimestamp = time.Now()
 		checkupStatus.Results = status.Results{
-			TrafficGeneratorMaxDropRate: expectedDropRate,
-			DPDKVMNode:                  expectedDPDKVMNode,
-			TrafficGeneratorNode:        expectedTrafficGeneratorNode,
+			TrafficGeneratorMaxDropRate:     expectedTrafficGeneratorMaxDropRate,
+			TrafficGeneratorOutErrorPackets: expectedTrafficGeneratorOutErrorPackets,
+			DPDKPacketsRxDropped:            expectedDPDKPacketsRxDropped,
+			DPDKPacketsTxDropped:            expectedDPDKPacketsTxDropped,
+			DPDKVMNode:                      expectedDPDKVMNode,
+			TrafficGeneratorNode:            expectedTrafficGeneratorNode,
 		}
 
 		assert.NoError(t, testReporter.Report(checkupStatus))
 
 		expectedReportData := map[string]string{
-			"status.succeeded":                   strconv.FormatBool(true),
-			"status.failureReason":               "",
-			"status.startTimestamp":              timestamp(checkupStatus.StartTimestamp),
-			"status.completionTimestamp":         timestamp(checkupStatus.CompletionTimestamp),
-			"status.result.dropRate":             fmt.Sprintf("%f", checkupStatus.Results.TrafficGeneratorMaxDropRate),
-			"status.result.trafficGeneratorNode": checkupStatus.Results.TrafficGeneratorNode,
-			"status.result.DPDKVMNodeKey":        checkupStatus.Results.DPDKVMNode,
+			"status.succeeded":                                 strconv.FormatBool(true),
+			"status.failureReason":                             "",
+			"status.startTimestamp":                            timestamp(checkupStatus.StartTimestamp),
+			"status.completionTimestamp":                       timestamp(checkupStatus.CompletionTimestamp),
+			"status.result.trafficGeneratorMaxDropRate":        fmt.Sprintf("%f", checkupStatus.Results.TrafficGeneratorMaxDropRate),
+			"status.result.trafficGeneratorOutputErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
+			"status.result.DPDKRxPacketDrops":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
+			"status.result.DPDKTxPacketDrops":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
+			"status.result.trafficGeneratorNode":               checkupStatus.Results.TrafficGeneratorNode,
+			"status.result.DPDKVMNodeKey":                      checkupStatus.Results.DPDKVMNode,
 		}
 
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -73,9 +73,9 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		checkupStatus.FailureReason = []string{}
 		checkupStatus.CompletionTimestamp = time.Now()
 		checkupStatus.Results = status.Results{
-			DropRate:             expectedDropRate,
-			DPDKVMNode:           expectedDPDKVMNode,
-			TrafficGeneratorNode: expectedTrafficGeneratorNode,
+			TrafficGeneratorMaxDropRate: expectedDropRate,
+			DPDKVMNode:                  expectedDPDKVMNode,
+			TrafficGeneratorNode:        expectedTrafficGeneratorNode,
 		}
 
 		assert.NoError(t, testReporter.Report(checkupStatus))
@@ -85,7 +85,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.failureReason":               "",
 			"status.startTimestamp":              timestamp(checkupStatus.StartTimestamp),
 			"status.completionTimestamp":         timestamp(checkupStatus.CompletionTimestamp),
-			"status.result.dropRate":             fmt.Sprintf("%d", checkupStatus.Results.DropRate),
+			"status.result.dropRate":             fmt.Sprintf("%f", checkupStatus.Results.TrafficGeneratorMaxDropRate),
 			"status.result.trafficGeneratorNode": checkupStatus.Results.TrafficGeneratorNode,
 			"status.result.DPDKVMNodeKey":        checkupStatus.Results.DPDKVMNode,
 		}

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -22,9 +22,12 @@ package status
 import kstatus "github.com/kiagnose/kiagnose/kiagnose/status"
 
 type Results struct {
-	DropRate             int
-	TrafficGeneratorNode string
-	DPDKVMNode           string
+	DropRate                        int
+	TrafficGeneratorOutErrorPackets int
+	DPDKPacketsRxDropped            int64
+	DPDKPacketsTxDropped            int64
+	TrafficGeneratorNode            string
+	DPDKVMNode                      string
 }
 
 type Status struct {

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -22,7 +22,7 @@ package status
 import kstatus "github.com/kiagnose/kiagnose/kiagnose/status"
 
 type Results struct {
-	DropRate                        int
+	TrafficGeneratorMaxDropRate     float64
 	TrafficGeneratorOutErrorPackets int
 	DPDKPacketsRxDropped            int64
 	DPDKPacketsTxDropped            int64


### PR DESCRIPTION
This PR add the results collected from the executer module to the results struct, making the checkup operational.

pushed on top of #48