### PR TITLE
Build custom VM container disk image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _output
 # Cache
 _linter-cache
 _go-cache
+_virt_builder

--- a/Makefile
+++ b/Makefile
@@ -125,3 +125,7 @@ build-vm-image: build-vm-image-builder
 build-vm-container-disk: build-vm-image
 	$(CRI_BIN) build $(CURDIR) -f $(CURDIR)/vm/Dockerfile -t $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(VM_CONTAINER_DISK_IMAGE_TAG)
 .PHONY: build-vm-container-disk
+
+push-vm-container-disk:
+	$(CRI_BIN) push $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(VM_CONTAINER_DISK_IMAGE_TAG)
+.PHONY: push-vm-container-disk

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ VM_IMAGE_BUILDER_IMAGE_NAME := kubevirt-dpdk-checkup-vm-image-builder
 VM_IMAGE_BUILDER_IMAGE_TAG ?= latest
 VIRT_BUILDER_CACHE_DIR := $(CURDIR)/_virt_builder/cache
 VIRT_BUILDER_OUTPUT_DIR := $(CURDIR)/_virt_builder/output
+VM_CONTAINER_DISK_IMAGE_NAME := kubevirt-dpdk-checkup-vm
+VM_CONTAINER_DISK_IMAGE_TAG ?= latest
 GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.19
 BIN_DIR = $(CURDIR)/_output/bin
@@ -119,3 +121,7 @@ build-vm-image: build-vm-image-builder
       $(REG)/$(ORG)/$(VM_IMAGE_BUILDER_IMAGE_NAME):$(VM_IMAGE_BUILDER_IMAGE_TAG) \
       /root/scripts/build-vm-image
 .PHONY: build-vm-image
+
+build-vm-container-disk: build-vm-image
+	$(CRI_BIN) build $(CURDIR) -f $(CURDIR)/vm/Dockerfile -t $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(VM_CONTAINER_DISK_IMAGE_TAG)
+.PHONY: build-vm-container-disk

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ CHECKUP_GIT_TAG ?= $(shell git describe --always --abbrev=8 --tags)
 TRAFFIC_GEN_IMAGE_NAME ?= kubevirt-dpdk-checkup-traffic-gen
 TRAFFIC_GEN_IMAGE_TAG ?= latest
 TRAFFIC_GEN_GIT_TAG ?= $(CHECKUP_GIT_TAG)
+VM_IMAGE_BUILDER_IMAGE_NAME := kubevirt-dpdk-checkup-vm-image-builder
+VM_IMAGE_BUILDER_IMAGE_TAG ?= latest
 GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.19
 BIN_DIR = $(CURDIR)/_output/bin
@@ -99,3 +101,7 @@ vendor:
 	           --workdir $(CURDIR) \
 	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go mod tidy -compat=$(GO_MOD_VERSION) && go mod vendor
 .PHONY: vendor
+
+build-vm-image-builder:
+	$(CRI_BIN) build $(CURDIR)/vm/image-builder -f $(CURDIR)/vm/image-builder/Dockerfile -t $(REG)/$(ORG)/$(VM_IMAGE_BUILDER_IMAGE_NAME):$(VM_IMAGE_BUILDER_IMAGE_TAG)
+.PHONY: build-vm-image-builder

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ TRAFFIC_GEN_IMAGE_TAG ?= latest
 TRAFFIC_GEN_GIT_TAG ?= $(CHECKUP_GIT_TAG)
 VM_IMAGE_BUILDER_IMAGE_NAME := kubevirt-dpdk-checkup-vm-image-builder
 VM_IMAGE_BUILDER_IMAGE_TAG ?= latest
+VIRT_BUILDER_CACHE_DIR := $(CURDIR)/_virt_builder/cache
+VIRT_BUILDER_OUTPUT_DIR := $(CURDIR)/_virt_builder/output
 GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.19
 BIN_DIR = $(CURDIR)/_output/bin
@@ -105,3 +107,15 @@ vendor:
 build-vm-image-builder:
 	$(CRI_BIN) build $(CURDIR)/vm/image-builder -f $(CURDIR)/vm/image-builder/Dockerfile -t $(REG)/$(ORG)/$(VM_IMAGE_BUILDER_IMAGE_NAME):$(VM_IMAGE_BUILDER_IMAGE_TAG)
 .PHONY: build-vm-image-builder
+
+build-vm-image: build-vm-image-builder
+	mkdir -vp $(VIRT_BUILDER_CACHE_DIR)
+	mkdir -vp $(VIRT_BUILDER_OUTPUT_DIR)
+
+	$(CRI_BIN) container run --rm \
+      --volume=$(VIRT_BUILDER_CACHE_DIR):/root/.cache/virt-builder:Z \
+      --volume=$(VIRT_BUILDER_OUTPUT_DIR):/output:Z \
+      --volume=$(CURDIR)/vm/scripts:/root/scripts:Z \
+      $(REG)/$(ORG)/$(VM_IMAGE_BUILDER_IMAGE_NAME):$(VM_IMAGE_BUILDER_IMAGE_TAG) \
+      /root/scripts/build-vm-image
+.PHONY: build-vm-image

--- a/vm/Dockerfile
+++ b/vm/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY ./_virt_builder/output/kubevirt-dpdk-checkup-vm.qcow2 /disk/

--- a/vm/image-builder/Dockerfile
+++ b/vm/image-builder/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf install -y libguestfs-tools && \
+    dnf clean all

--- a/vm/scripts/build-vm-image
+++ b/vm/scripts/build-vm-image
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+
+export LIBGUESTFS_BACKEND=direct
+
+virt-builder centosstream-8 \
+  --format qcow2 \
+  --root-password password:redhat \
+  --install cloud-init,dpdk,dpdk-tools,driverctl,tuned-profiles-cpu-partitioning \
+  --run /root/scripts/customize-vm \
+  --firstboot /root/scripts/first-boot \
+  --selinux-relabel \
+  --output /output/kubevirt-dpdk-checkup-vm.qcow2

--- a/vm/scripts/customize-vm
+++ b/vm/scripts/customize-vm
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+
+systemctl disable NetworkManager-wait-online
+systemctl disable sshd
+
+grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=8 isolcpus=2-7"
+
+echo  isolated_cores=2-7 > /etc/tuned/cpu-partitioning-variables.conf
+tuned-adm profile cpu-partitioning
+echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf

--- a/vm/scripts/first-boot
+++ b/vm/scripts/first-boot
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+
+driverctl set-override 0000:06:00.0 vfio-pci
+driverctl set-override 0000:07:00.0 vfio-pci
+
+mkdir /mnt/huge
+mount /mnt/huge --source nodev -t hugetlbfs -o pagesize=1GB


### PR DESCRIPTION
Currently, the checkup uses a hard-codded name of a PVC containing a custom image.
In order for the checkup to be usable for other users, build a container disk [1] image.

Process description:
1. Bulid the vm-image-builder container image - this will be the environment to build the custom qcow2 image.
2. Build the custom qcow2 image using `virt-builder` [2].
3. Containerize the qcow2 image, so it could be consumed by KubeVirt.
4. Push the container disk image to `quay.io/kiagnose/kubevirt-dpdk-checkup-vm`.

```bash
make build-vm-container-disk
make push-vm-container-disk
```

A follow-up PR will add the URL of this image to the checkup's configuration.

[1] https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk
[2] https://libguestfs.org/virt-builder.1.html