### PR TITLE
checkup: Get last updated vmi after waiting to be booted

### DIFF
--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -35,7 +35,7 @@ const (
 	DPDKRxDropsKey                     = "DPDKRxPacketDrops"
 	DPDKTxDropsKey                     = "DPDKTxPacketDrops"
 	TrafficGeneratorNodeKey            = "trafficGeneratorNode"
-	DPDKVMNodeKey                      = "DPDKVMNodeKey"
+	DPDKVMNodeKey                      = "DPDKVMNode"
 )
 
 type Reporter struct {

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -96,7 +96,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.DPDKRxPacketDrops":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 			"status.result.DPDKTxPacketDrops":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 			"status.result.trafficGeneratorNode":               checkupStatus.Results.TrafficGeneratorNode,
-			"status.result.DPDKVMNodeKey":                      checkupStatus.Results.DPDKVMNode,
+			"status.result.DPDKVMNode":                         checkupStatus.Results.DPDKVMNode,
 		}
 
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -97,8 +97,8 @@ var _ = Describe("Execute the checkup Job", func() {
 		Expect(configMap.Data["status.failureReason"]).To(BeEmpty(), fmt.Sprintf("should be empty %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.trafficGeneratorNode"]).ToNot(BeEmpty(),
 			fmt.Sprintf("trafficGeneratorNode should not be empty %+v", prettifyData(configMap.Data)))
-		Expect(configMap.Data["status.DPDKVMNodeKey"]).ToNot(BeEmpty(),
-			fmt.Sprintf("DPDKVMNodeKey should not be empty %+v", prettifyData(configMap.Data)))
+		Expect(configMap.Data["status.DPDKVMNode"]).ToNot(BeEmpty(),
+			fmt.Sprintf("DPDKVMNode should not be empty %+v", prettifyData(configMap.Data)))
 	})
 })
 

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -95,6 +95,10 @@ var _ = Describe("Execute the checkup Job", func() {
 		Expect(configMap.Data).NotTo(BeNil())
 		Expect(configMap.Data["status.succeeded"]).To(Equal("true"), fmt.Sprintf("should succeed %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.failureReason"]).To(BeEmpty(), fmt.Sprintf("should be empty %+v", prettifyData(configMap.Data)))
+		Expect(configMap.Data["status.trafficGeneratorNode"]).ToNot(BeEmpty(),
+			fmt.Sprintf("trafficGeneratorNode should not be empty %+v", prettifyData(configMap.Data)))
+		Expect(configMap.Data["status.DPDKVMNodeKey"]).ToNot(BeEmpty(),
+			fmt.Sprintf("DPDKVMNodeKey should not be empty %+v", prettifyData(configMap.Data)))
 	})
 })
 


### PR DESCRIPTION
This PR fixed a bug where the results configmap did not register the vmi node name.
The vmi is saved after the vmi is booted, thus making sure the node name is set on it.

Also fixing a typo in the node name key