### PR TITLE
executer, trex-console: Change context usage

### DIFF
--- a/pkg/internal/checkup/executor/trex-console.go
+++ b/pkg/internal/checkup/executor/trex-console.go
@@ -61,7 +61,7 @@ func (t trexConsole) MonitorDropRates(ctx context.Context, duration time.Duratio
 	log.Printf("Monitoring traffic generator side drop rates every %ss during the test duration...", interval)
 	maxDropRateBps := float64(0)
 
-	ctxWithNewDeadline, cancel := context.WithDeadline(ctx, time.Now().Add(duration))
+	ctxWithNewDeadline, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 	conditionFn := func(ctx context.Context) (bool, error) {
 		statsGlobal, err := t.GetGlobalStats(ctx)


### PR DESCRIPTION
This PR does a small refactoring of the way we get the context in the `MonitorDropRates` function.