### PR TITLE
executer, trex-console: Fix duration format

### DIFF
--- a/pkg/internal/checkup/executor/trex-console.go
+++ b/pkg/internal/checkup/executor/trex-console.go
@@ -86,9 +86,9 @@ func (t trexConsole) ClearStats(ctx context.Context) (string, error) {
 }
 
 func (t trexConsole) StartTraffic(ctx context.Context, packetPerSecondMillion, port int, testDuration time.Duration) (string, error) {
-	testDurationMinutes := int(testDuration.Minutes())
-	return t.runCommand(ctx, fmt.Sprintf("start -f /opt/tests/testpmd.py -m %dmpps -p %d -d %dm",
-		packetPerSecondMillion, port, testDurationMinutes))
+	testDurationSeconds := int(testDuration.Seconds())
+	return t.runCommand(ctx, fmt.Sprintf("start -f /opt/tests/testpmd.py -m %dmpps -p %d -d %d",
+		packetPerSecondMillion, port, testDurationSeconds))
 }
 
 func (t trexConsole) StopTraffic(ctx context.Context) (string, error) {


### PR DESCRIPTION
Currently the duration is set in minutes, making it so that the granularity of the test duration is minutes.
This is changed to allow seconds granularity [0]

[0] https://trex-tgn.cisco.com/trex/doc/trex_console.html, section 1.3.3.