### PR TITLE
Remove NUMA socket param

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ roleRef:
 | Key                                         | Description                                                                                                       | Is Mandatory | Remarks                                                                                                |
 |---------------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------|--------------------------------------------------------------------------------------------------------|
 | spec.timeout                                | How much time before the checkup will try to close itself                                                         | True         |                                                                                                        |
-| spec.param.NUMASocket                       | The NUMA node where the workloads shall be scheduled to                                                           | True         |                                                                                                        |
 | spec.param.networkAttachmentDefinitionName  | NetworkAttachmentDefinition name of the SR-IOV NICs connected                                                     | True         | Assumed to be in the same namespace                                                                    |
 | spec.param.trafficGeneratorRuntimeClassName | [Runtime Class](https://kubernetes.io/docs/concepts/containers/runtime-class/) the traffic generator pod will use | True         |                                                                                                        |
 | spec.param.trafficGeneratorImage            | Traffic generator's container image                                                                               | False        | Defaults to the U/S image https://quay.io/repository/kiagnose/kubevirt-dpdk-checkup-traffic-gen:latest |
@@ -95,7 +94,6 @@ metadata:
   name: dpdk-checkup-config
 data:
   spec.timeout: 10m
-  spec.param.NUMASocket: 0
   spec.param.networkAttachmentDefinitionName: <network-name>
   spec.param.trafficGeneratorRuntimeClassName: <runtimeclass-name>
   spec.param.trafficGeneratorImage: quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:latest

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -384,7 +384,6 @@ func newTrafficGeneratorPod(checkupConfig config.Config, secondaryNetworkRequest
 		terminationGracePeriodSeconds          = int64(0)
 
 		portBandwidthParamName     = "PORT_BANDWIDTH_GB"
-		numaSocketParamName        = "NUMA_SOCKET"
 		verboseParamName           = "SET_VERBOSE"
 		numTrafficCpusParamName    = "NUM_OF_TRAFFIC_CPUS"
 		numCpusParamName           = "NUM_OF_CPUS"
@@ -396,7 +395,6 @@ func newTrafficGeneratorPod(checkupConfig config.Config, secondaryNetworkRequest
 
 	envVars := map[string]string{
 		portBandwidthParamName:     fmt.Sprintf("%d", checkupConfig.PortBandwidthGB),
-		numaSocketParamName:        fmt.Sprintf("%d", checkupConfig.NUMASocket),
 		numTrafficCpusParamName:    fmt.Sprintf("%d", trafficGeneratorPodCPUCount-trafficGeneratorPodNumOfNonTrafficCPUs),
 		numCpusParamName:           fmt.Sprintf("%d", trafficGeneratorPodCPUCount),
 		srcWestMACAddressParamName: checkupConfig.TrafficGeneratorWestMacAddress.String(),

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -375,7 +375,6 @@ func newTestConfig() config.Config {
 	return config.Config{
 		PodName:                           testPodName,
 		PodUID:                            testPodUID,
-		NUMASocket:                        0,
 		NetworkAttachmentDefinitionName:   testNetworkAttachmentDefinitionName,
 		TrafficGeneratorNodeLabelSelector: "",
 		DPDKNodeLabelSelector:             "",

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	NUMASocketParamName                                 = "NUMASocket"
 	NetworkAttachmentDefinitionNameParamName            = "networkAttachmentDefinitionName"
 	TrafficGeneratorRuntimeClassNameParamName           = "trafficGeneratorRuntimeClassName"
 	TrafficGeneratorNodeLabelSelectorParamName          = "trafficGeneratorNodeLabelSelector"
@@ -66,7 +65,6 @@ const (
 )
 
 var (
-	ErrInvalidNUMASocket                                 = errors.New("invalid NUMA Socket")
 	ErrInvalidNetworkAttachmentDefinitionName            = errors.New("invalid Network-Attachment-Definition Name")
 	ErrInvalidTrafficGeneratorRuntimeClassName           = errors.New("invalid Traffic Generator Runtime class Name")
 	ErrInvalidTrafficGeneratorNodeLabelSelector          = errors.New("invalid Traffic Generator Node Label Selector")
@@ -83,7 +81,6 @@ var (
 type Config struct {
 	PodName                                    string
 	PodUID                                     string
-	NUMASocket                                 int
 	TrafficGeneratorRuntimeClassName           string
 	NetworkAttachmentDefinitionName            string
 	TrafficGeneratorNodeLabelSelector          string
@@ -121,16 +118,6 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		VMContainerDiskImage:                       VMContainerDiskImageDefault,
 		TestDuration:                               TestDurationDefault,
 	}
-
-	var rawNUMASocket string
-	if rawNUMASocket = baseConfig.Params[NUMASocketParamName]; rawNUMASocket == "" {
-		return Config{}, ErrInvalidNUMASocket
-	}
-	numaSocket, err := parseNonNegativeInt(rawNUMASocket)
-	if err != nil {
-		return Config{}, ErrInvalidNUMASocket
-	}
-	newConfig.NUMASocket = numaSocket
 
 	if newConfig.NetworkAttachmentDefinitionName == "" {
 		return Config{}, ErrInvalidNetworkAttachmentDefinitionName

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -35,7 +35,6 @@ import (
 const (
 	testPodName                                = "my-pod"
 	testPodUID                                 = "0123456789-0123456789"
-	numaSocket                                 = 1
 	networkAttachmentDefinitionName            = "intel-dpdk-network1"
 	trafficGeneratorRuntimeClassName           = "dpdk-runtimeclass"
 	portBandwidthGB                            = 100
@@ -56,7 +55,6 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		PodName: testPodName,
 		PodUID:  testPodUID,
 		Params: map[string]string{
-			config.NUMASocketParamName:                       fmt.Sprintf("%d", numaSocket),
 			config.NetworkAttachmentDefinitionNameParamName:  networkAttachmentDefinitionName,
 			config.TrafficGeneratorRuntimeClassNameParamName: trafficGeneratorRuntimeClassName,
 		},
@@ -72,7 +70,6 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 	expectedConfig := config.Config{
 		PodName:                          testPodName,
 		PodUID:                           testPodUID,
-		NUMASocket:                       numaSocket,
 		TrafficGeneratorRuntimeClassName: trafficGeneratorRuntimeClassName,
 		NetworkAttachmentDefinitionName:  networkAttachmentDefinitionName,
 		TrafficGeneratorPacketsPerSecondInMillions: config.TrafficGeneratorPacketsPerSecondInMillionsDefault,
@@ -105,7 +102,6 @@ func TestNewShouldApplyUserConfig(t *testing.T) {
 	expectedConfig := config.Config{
 		PodName:                          testPodName,
 		PodUID:                           testPodUID,
-		NUMASocket:                       numaSocket,
 		TrafficGeneratorRuntimeClassName: trafficGeneratorRuntimeClassName,
 		PortBandwidthGB:                  portBandwidthGB,
 		NetworkAttachmentDefinitionName:  networkAttachmentDefinitionName,
@@ -132,18 +128,6 @@ func TestNewShouldFailWhen(t *testing.T) {
 	}
 
 	testCases := []failureTestCase{
-		{
-			description:    "NUMA Socket is empty string",
-			key:            config.NUMASocketParamName,
-			faultyKeyValue: "",
-			expectedError:  config.ErrInvalidNUMASocket,
-		},
-		{
-			description:    "NUMA Socket is invalid",
-			key:            config.NUMASocketParamName,
-			faultyKeyValue: "-1",
-			expectedError:  config.ErrInvalidNUMASocket,
-		},
 		{
 			description:    "Traffic Generator Runtimeclass Name is invalid",
 			key:            config.TrafficGeneratorRuntimeClassNameParamName,
@@ -219,7 +203,6 @@ func TestNewShouldFailWhen(t *testing.T) {
 
 func getValidUserParameters() map[string]string {
 	return map[string]string{
-		config.NUMASocketParamName:                                 fmt.Sprintf("%d", numaSocket),
 		config.TrafficGeneratorRuntimeClassNameParamName:           trafficGeneratorRuntimeClassName,
 		config.NetworkAttachmentDefinitionNameParamName:            networkAttachmentDefinitionName,
 		config.PortBandwidthGBParamName:                            fmt.Sprintf("%d", portBandwidthGB),

--- a/pkg/mainflow.go
+++ b/pkg/mainflow.go
@@ -66,7 +66,6 @@ func Run(rawEnv map[string]string, namespace string) error {
 
 func printConfig(checkupConfig config.Config) {
 	log.Println("Using the following config:")
-	log.Printf("%q: %q", config.NUMASocketParamName, fmt.Sprintf("%d", checkupConfig.NUMASocket))
 	log.Printf("%q: %q", config.NetworkAttachmentDefinitionNameParamName, checkupConfig.NetworkAttachmentDefinitionName)
 	log.Printf("%q: %q", config.PortBandwidthGBParamName, fmt.Sprintf("%d", checkupConfig.PortBandwidthGB))
 	log.Printf("%q: %q", config.TrafficGeneratorNodeLabelSelectorParamName, checkupConfig.TrafficGeneratorNodeLabelSelector)

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -41,8 +41,6 @@ const (
 	testKubeVirtDPDKCheckerRoleName     = "kubevirt-dpdk-checker"
 	testConfigMapName                   = "dpdk-checkup-config"
 	testCheckupJobName                  = "dpdk-checkup"
-
-	paramNUMASocket = "0"
 )
 
 var _ = Describe("Execute the checkup Job", func() {
@@ -295,8 +293,7 @@ func newConfigMap() *corev1.ConfigMap {
 			Name: testConfigMapName,
 		},
 		Data: map[string]string{
-			"spec.timeout":                                "10m",
-			"spec.param.NUMASocket":                       paramNUMASocket,
+			"spec.timeout": "10m",
 			"spec.param.networkAttachmentDefinitionName":  networkAttachmentDefinitionName,
 			"spec.param.trafficGeneratorRuntimeClassName": runtimeClassName,
 			"spec.param.trafficGeneratorImage":            trafficGeneratorImage,


### PR DESCRIPTION
This PR is removing the NUMASocket param from the configmap, in favor of a dynamic set of it inside the traffic-gen pod