### PR TITLE
github actions: Preparation for first release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'release-**'
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'release-**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CRI_BIN: podman
+      CHECKUP_IMAGE_TAG: ${{github.ref_name}}
+      TRAFFIC_GEN_IMAGE_TAG: ${{github.ref_name}}
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
In preparation for the first release, tag the checkup and traffic generator images with the release name, for example: `v0.1.0`.

The Latest image tag will be `main`.

Also add a trigger to the CI on release branches.
