### PR TITLE
Update checkups image tags to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network-name>
   spec.param.trafficGeneratorRuntimeClassName: <runtimeclass-name>
-  spec.param.trafficGeneratorImage: quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:latest
+  spec.param.trafficGeneratorImage: quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main
 ```
 
 ## Execution

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -52,8 +52,8 @@ const (
 	TrafficGeneratorWestMacAddressDefault             = "50:00:00:00:00:02"
 	DPDKEastMacAddressDefault                         = "60:00:00:00:00:01"
 	DPDKWestMacAddressDefault                         = "60:00:00:00:00:02"
-	TrafficGeneratorImageDefault                      = "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:latest"
-	VMContainerDiskImageDefault                       = "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:latest"
+	TrafficGeneratorImageDefault                      = "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main"
+	VMContainerDiskImageDefault                       = "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main"
 	TestDurationDefault                               = 5 * time.Minute
 	VerboseDefault                                    = false
 )

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -46,8 +46,8 @@ const (
 	trafficGeneratorWestMacAddress             = "DE:AD:BE:EF:01:00"
 	dpdkEastMacAddress                         = "DE:AD:BE:EF:00:02"
 	dpdkWestMacAddress                         = "DE:AD:BE:EF:02:00"
-	trafficGeneratorImage                      = "quay.io/ramlavi/kubevirt-dpdk-checkup-traffic-gen:latest"
-	vmContainerDiskImage                       = "quay.io/ramlavi/kubevirt-dpdk-checkup-vm:latest"
+	trafficGeneratorImage                      = "quay.io/ramlavi/kubevirt-dpdk-checkup-traffic-gen:main"
+	vmContainerDiskImage                       = "quay.io/ramlavi/kubevirt-dpdk-checkup-vm:main"
 	testDuration                               = "30m"
 )
 

--- a/tests/test_suite_test.go
+++ b/tests/test_suite_test.go
@@ -45,7 +45,7 @@ const (
 
 const (
 	defaultNamespace                       = "kiagnose-demo"
-	defaultImageName                       = "quay.io/kiagnose/kubevirt-dpdk-checkup:latest"
+	defaultImageName                       = "quay.io/kiagnose/kubevirt-dpdk-checkup:main"
 	defaultNetworkAttachmentDefinitionName = "intel-dpdk-network-1"
 	defaultRuntimeClassName                = "performance-performance-zeus10"
 )


### PR DESCRIPTION
Currently running the checkup with only mandatory parameters is broken, following the change done in #65 , where the default image tags were changed to `main`. 

In order to be able to run the checkup with only mandatory image params, aligning the default values of the dpdk-checkup, traffic-generator and DPDK vmi