### PR TITLE
README: Remove optional param from configmap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network-name>
   spec.param.trafficGeneratorRuntimeClassName: <runtimeclass-name>
-  spec.param.trafficGeneratorImage: quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main
 ```
 
 ## Execution


### PR DESCRIPTION
This PR removes an optional param `trafficGeneratorImage` from configmap example.
As this param is optional, it has a default value, if it is not set.