### PR TITLE
execute, testpmd: Use only isolated CPUs

### DIFF
--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -275,8 +275,8 @@ func parseTestpmdStats(input string) (map[string]int64, error) {
 
 func buildTestpmdCmd(vmiEastNICPCIAddress, vmiWestNICPCIAddress, eastEthPeerMACAddress, westEthPeerMACAddress string) string {
 	const (
-		cpuList       = "0-7"
-		numberOfCores = 7
+		cpuList       = "2-7"
+		numberOfCores = 5
 	)
 
 	sb := strings.Builder{}


### PR DESCRIPTION
Currently the testpmd is forwarding on all CPUs given to it. In order to make sure that the packets are received and forwarded only on CPUs set as isolated by linux /proc/cmdline (set [here](https://github.com/kiagnose/kubevirt-dpdk-checkup/blob/6685c0060021275c115a1f58c661e253f5ca9dec/vm/scripts/customize-vm#L23)), changing the CPUs on the dpdk-testpmd command accordingly.

Also setting nb-cores according to [dpdk manual](https://doc.dpdk.org/guides/testpmd_app_ug/run_app.html).