### PR TITLE
checkup, vmi: Always pull VM ContainerDisk image

### DIFF
--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -211,7 +211,8 @@ func WithContainerDisk(volumeName, imageName string) Option {
 			Name: volumeName,
 			VolumeSource: kvcorev1.VolumeSource{
 				ContainerDisk: &kvcorev1.ContainerDiskSource{
-					Image: imageName,
+					Image:           imageName,
+					ImagePullPolicy: corev1.PullAlways,
 				},
 			},
 		}


### PR DESCRIPTION
Following PR #65 [1], the latest image tag is "main". This now causes KubeVirt to use the "IfNotPresent" ImagePullPolicy [2], where before it was implicitly "PullAlways".

Explicitly use the "PullAlways" policy.

Manually tested against an OpenShift Virtualization 4.12 cluster.

[1] https://github.com/kiagnose/kubevirt-dpdk-checkup/pull/65
[2] http://kubevirt.io/api-reference/v0.58.1/definitions.html#_v1_containerdisksource