### PR TITLE
checkup, traffic-gen: Add ierrors result

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 | status.completionTimestamp                       | Checkup completion timestamp                                      | RFC 3339 |
 | status.result.trafficGeneratorMaxDropRate        | Max drop rate sampled out of traffic sent                         |          |
 | status.result.trafficGeneratorOutputErrorPackets | Indicates error sending packets from traffic generator            |          |
+| status.result.trafficGeneratorInErrorPackets     | Indicates error receiving packets to traffic generator            |          |
 | status.result.trafficGeneratorNode               | Node name on which the traffic generator Pod was scheduled        |          |
 | status.result.DPDKVMNode                         | Node name on which the DPDK VMI was scheduled                     |          |
 | status.result.DPDKRxPacketDrops                  | Indicates ingress packets that were dropped from DPDK application |          |

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -121,8 +121,9 @@ func (c *Checkup) Run(ctx context.Context) error {
 		return fmt.Errorf("detected %f Bps Drop Rate on the traffic generator's side", c.results.TrafficGeneratorMaxDropRate)
 	}
 
-	if c.results.TrafficGeneratorOutErrorPackets != 0 {
-		return fmt.Errorf("detected %d Output Error Packets on the traffic generator's side", c.results.TrafficGeneratorOutErrorPackets)
+	if c.results.TrafficGeneratorOutErrorPackets != 0 || c.results.TrafficGeneratorInErrorPackets != 0 {
+		return fmt.Errorf("detected Error Packets on the traffic generator's side: Oerrors %d Ierrors %d",
+			c.results.TrafficGeneratorOutErrorPackets, c.results.TrafficGeneratorInErrorPackets)
 	}
 
 	if c.results.DPDKPacketsRxDropped != 0 || c.results.DPDKPacketsTxDropped != 0 {

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -127,13 +127,16 @@ func (e Executor) Execute(ctx context.Context, vmiName, podName, podContainerNam
 		return status.Results{}, err
 	}
 
-	_, err = trexClient.GetPortStats(ctx, trafficDestPort)
+	var trafficGeneratorDstPortStats portStats
+	trafficGeneratorDstPortStats, err = trexClient.GetPortStats(ctx, trafficDestPort)
 	if err != nil {
 		return status.Results{}, err
 	}
 
 	results.TrafficGeneratorOutErrorPackets = trafficGeneratorSrcPortStats.Result.Oerrors
 	log.Printf("traffic Generator port %d Packet output errors: %d", trafficSourcePort, results.TrafficGeneratorOutErrorPackets)
+	results.TrafficGeneratorInErrorPackets = trafficGeneratorDstPortStats.Result.Ierrors
+	log.Printf("traffic Generator port %d Packet output errors: %d", trafficDestPort, results.TrafficGeneratorInErrorPackets)
 
 	log.Printf("get testpmd stats in DPDK VMI...")
 	var testPmdStats map[string]int64

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -32,6 +32,7 @@ import (
 const (
 	TrafficGeneratorMaxDropRateKey     = "trafficGeneratorMaxDropRate"
 	TrafficGeneratorOutErrorPacketsKey = "trafficGeneratorOutputErrorPackets"
+	TrafficGeneratorInErrorPacketsKey  = "trafficGeneratorInErrorPackets"
 	DPDKRxDropsKey                     = "DPDKRxPacketDrops"
 	DPDKTxDropsKey                     = "DPDKTxPacketDrops"
 	TrafficGeneratorNodeKey            = "trafficGeneratorNode"
@@ -68,6 +69,7 @@ func formatResults(checkupStatus status.Status) map[string]string {
 	formattedResults := map[string]string{
 		TrafficGeneratorMaxDropRateKey:     fmt.Sprintf("%f", checkupStatus.Results.TrafficGeneratorMaxDropRate),
 		TrafficGeneratorOutErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
+		TrafficGeneratorInErrorPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorInErrorPackets),
 		DPDKRxDropsKey:                     fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 		DPDKTxDropsKey:                     fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 		TrafficGeneratorNodeKey:            checkupStatus.Results.TrafficGeneratorNode,

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -54,6 +54,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 	const (
 		expectedTrafficGeneratorMaxDropRate     = 0
 		expectedTrafficGeneratorOutErrorPackets = 0
+		expectedTrafficGeneratorInErrorPackets  = 0
 		expectedDPDKPacketsRxDropped            = 0
 		expectedDPDKPacketsTxDropped            = 0
 		expectedDPDKVMNode                      = "dpdk-node01"
@@ -78,6 +79,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		checkupStatus.Results = status.Results{
 			TrafficGeneratorMaxDropRate:     expectedTrafficGeneratorMaxDropRate,
 			TrafficGeneratorOutErrorPackets: expectedTrafficGeneratorOutErrorPackets,
+			TrafficGeneratorInErrorPackets:  expectedTrafficGeneratorInErrorPackets,
 			DPDKPacketsRxDropped:            expectedDPDKPacketsRxDropped,
 			DPDKPacketsTxDropped:            expectedDPDKPacketsTxDropped,
 			DPDKVMNode:                      expectedDPDKVMNode,
@@ -93,6 +95,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.completionTimestamp":                       timestamp(checkupStatus.CompletionTimestamp),
 			"status.result.trafficGeneratorMaxDropRate":        fmt.Sprintf("%f", checkupStatus.Results.TrafficGeneratorMaxDropRate),
 			"status.result.trafficGeneratorOutputErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
+			"status.result.trafficGeneratorInErrorPackets":     fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
 			"status.result.DPDKRxPacketDrops":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 			"status.result.DPDKTxPacketDrops":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 			"status.result.trafficGeneratorNode":               checkupStatus.Results.TrafficGeneratorNode,

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -24,6 +24,7 @@ import kstatus "github.com/kiagnose/kiagnose/kiagnose/status"
 type Results struct {
 	TrafficGeneratorMaxDropRate     float64
 	TrafficGeneratorOutErrorPackets int
+	TrafficGeneratorInErrorPackets  int
 	DPDKPacketsRxDropped            int64
 	DPDKPacketsTxDropped            int64
 	TrafficGeneratorNode            string


### PR DESCRIPTION
This PR introduces a new criteria for failing the checkup. 
The checkup should fail if there were any ierrors present during the test.

This PR is pushed on top of #75 