### PR TITLE
traffic-gen: Align ports with DPDK VMI

### DIFF
--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -166,7 +166,7 @@ func (e Executor) Execute(ctx context.Context, vmiName, podName, podContainerNam
 	results.DPDKPacketsTxDropped = testPmdStats[testPmdPortStatsSummary].TXDropped
 	log.Printf("DPDK side packets Dropped: Rx: %d; TX: %d", results.DPDKPacketsRxDropped, results.DPDKPacketsTxDropped)
 	results.DPDKRxTestPackets =
-		testPmdStats[testPmdPortStatsSummary].RXTotal - testPmdStats[testPmdStatsPort0].RXPackets - testPmdStats[testPmdStatsPort1].TXPackets
+		testPmdStats[testPmdPortStatsSummary].RXTotal - testPmdStats[testPmdStatsPort0].TXPackets - testPmdStats[testPmdStatsPort1].RXPackets
 	log.Printf("DPDK side test packets received (including dropped, excluding non-related packets): %d", results.DPDKRxTestPackets)
 
 	return results, nil

--- a/traffic-gen/templates/testpmd.py.in
+++ b/traffic-gen/templates/testpmd.py.in
@@ -3,8 +3,8 @@ from trex_stl_lib.api import *
 from testpmd_addr import *
 
 # Wild local MACs
-mac_localport0="$SRC_WEST_MAC_ADDRESS"
-mac_localport1="$SRC_EAST_MAC_ADDRESS"
+mac_localport0="$SRC_EAST_MAC_ADDRESS"
+mac_localport1="$SRC_WEST_MAC_ADDRESS"
 
 class STLS1(object):
 

--- a/traffic-gen/templates/testpmd_addr.py.in
+++ b/traffic-gen/templates/testpmd_addr.py.in
@@ -1,7 +1,7 @@
 # wild first XL710 mac
-mac_telco0 = "$DST_WEST_MAC_ADDRESS"
+mac_telco0 = "$DST_EAST_MAC_ADDRESS"
 # wild second XL710 mac
-mac_telco1 = "$DST_EAST_MAC_ADDRESS"
+mac_telco1 = "$DST_WEST_MAC_ADDRESS"
 # we don’t care of the IP in this phase
 ip_telco0  = '10.0.0.1'
 ip_telco1 = '10.1.1.1'


### PR DESCRIPTION
currently the direction the traffic generator is sending the packets is from port 0 using the west src MAC, but since the DPDK application is configured to receive the east MAC on port 0, then the ports gets mixed. 

This does not effect the nature of the checkup, but for the sake of order, the checkup traffic diagram should be like this: 
```
traffic-gen[port 0] => dpdk-app[port 0] => dpdk-app[port 1] traffic-gen[port 1].
```
Switching the MACs on the traffic generator streams templates.