### PR TITLE
traffic-gen: Add verbose prints to trex daemon

### DIFF
--- a/traffic-gen/scripts/run_traffic_gen_daemon.sh
+++ b/traffic-gen/scripts/run_traffic_gen_daemon.sh
@@ -29,4 +29,4 @@ print_params() {
 
 print_params
 
-./t-rex-64 --no-ofed-check --no-hw-flow-stat -i -c "${NUM_OF_TRAFFIC_CPUS}" --iom 0
+./t-rex-64 --no-ofed-check --no-hw-flow-stat -i -v 3 -c "${NUM_OF_TRAFFIC_CPUS}" --iom 0


### PR DESCRIPTION
This option is available after upgrade to v3.02

depends on #82 