### PR TITLE
[WIP] VM under test, container disk image: Upgrade to CentOS Stream 9 

### DIFF
--- a/vms/vm-under-test/scripts/build-vm-image
+++ b/vms/vm-under-test/scripts/build-vm-image
@@ -19,7 +19,7 @@
 
 export LIBGUESTFS_BACKEND=direct
 
-virt-builder centosstream-8 \
+virt-builder centosstream-9 \
   --format qcow2 \
   --root-password password:redhat \
   --install cloud-init,dpdk,dpdk-tools,driverctl,tuned-profiles-cpu-partitioning \


### PR DESCRIPTION
Currently, we are building a container disk image based on CentOS Stream 8.
In order to enjoy the latest advancements, we now use CentOS Stream 9.

This PR depends on PR #173, please review only the last commit.