### PR TITLE
traffic-gen: Add no-scapy-server flag

### DIFF
--- a/traffic-gen/scripts/run_traffic_gen_daemon.sh
+++ b/traffic-gen/scripts/run_traffic_gen_daemon.sh
@@ -29,4 +29,4 @@ print_params() {
 
 print_params
 
-./t-rex-64 --no-ofed-check --no-hw-flow-stat -i -c "${NUM_OF_TRAFFIC_CPUS}" --iom 0
+./t-rex-64 --no-ofed-check --no-scapy-server --no-hw-flow-stat -i -c "${NUM_OF_TRAFFIC_CPUS}" --iom 0


### PR DESCRIPTION
This PR is removing the scapy server from running inside the traffic-generator pod.

The server is causing the application to crash on some machines. Since it is not necessary for the checkup, removing the scapy server by adding the flag.