### PR TITLE
[release 0.1] traffic-gen: Add no-scapy-server flag

### DIFF
--- a/traffic-gen/scripts/run_traffic_gen_daemon.sh
+++ b/traffic-gen/scripts/run_traffic_gen_daemon.sh
@@ -29,4 +29,4 @@ print_params() {
 
 print_params
 
-./t-rex-64 --no-ofed-check --no-hw-flow-stat -i -c "${NUM_OF_TRAFFIC_CPUS}" --iom 0
+./t-rex-64 --no-ofed-check --no-scapy-server --no-hw-flow-stat -i -c "${NUM_OF_TRAFFIC_CPUS}" --iom 0


### PR DESCRIPTION
This PR is a semi-auto cherry-pick of https://github.com/kiagnose/kubevirt-dpdk-checkup/pull/98

Fixes [BZ#2178629](https://bugzilla.redhat.com/show_bug.cgi?id=2178629)

