### PR TITLE
README: Change Job image to "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: dpdk-checkup
-          image: quay.io/kiagnose/kubevirt-dpdk-checkup:latest
+          image: quay.io/kiagnose/kubevirt-dpdk-checkup:main
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Following PR #63, the latest checkup's image tag is `main`. Update the Job's image tag in the README accordingly.