### PR TITLE
README: Remove `volumes` field from SCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ supplementalGroups:
   type: RunAsAny
 users:
 - system:serviceaccount:dpdk-checkup-ns:dpdk-checkup-traffic-gen-sa
-volumes:
-- hostPath
 ```
 
 ## Configuration


### PR DESCRIPTION
Currently, on OpenShift 4.13, the traffic-gen cannot be created. Remove the `volumes` field from the SCC, so the traffic-gen pod is successfully created.

Manually tested on an OpenShift 4.13 cluster.