### PR TITLE
checkup, setup: Cleanup VMI and Pod in case of error

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -83,17 +83,28 @@ func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config
 	}
 }
 
-func (c *Checkup) Setup(ctx context.Context) error {
+func (c *Checkup) Setup(ctx context.Context) (setupErr error) {
 	const errMessagePrefix = "setup"
 	var err error
 
 	if err = c.createVMI(ctx); err != nil {
 		return fmt.Errorf("%s: %w", errMessagePrefix, err)
 	}
+	defer func() {
+		if setupErr != nil {
+			c.cleanupVMI()
+		}
+	}()
 
 	if err = c.createTrafficGeneratorPod(ctx); err != nil {
 		return fmt.Errorf("%s: %w", errMessagePrefix, err)
 	}
+
+	defer func() {
+		if setupErr != nil {
+			c.cleanupPod()
+		}
+	}()
 
 	err = c.waitForVMIToBoot(ctx)
 	if err != nil {
@@ -241,6 +252,19 @@ func (c *Checkup) waitForVMIDeletion(ctx context.Context) error {
 	return nil
 }
 
+func (c *Checkup) cleanupVMI() {
+	const setupCleanupTimeout = 30 * time.Second
+
+	log.Printf("setup failed, cleanup VMI '%s/%s'", c.vmi.Namespace, c.vmi.Name)
+	delCtx, cancel := context.WithTimeout(context.Background(), setupCleanupTimeout)
+	defer cancel()
+	_ = c.deleteVMI(delCtx)
+
+	if derr := c.waitForVMIDeletion(delCtx); derr != nil {
+		log.Printf("Failed to cleanup VMI '%s/%s': %v", c.vmi.Namespace, c.vmi.Name, derr)
+	}
+}
+
 func (c *Checkup) createTrafficGeneratorPod(ctx context.Context) error {
 	secondaryNetworksRequest, err := pod.CreateNetworksRequest([]networkv1.NetworkSelectionElement{
 		{Name: c.params.NetworkAttachmentDefinitionName, Namespace: c.namespace, MacRequest: c.params.TrafficGeneratorEastMacAddress.String()},
@@ -349,6 +373,19 @@ func (c *Checkup) waitForPodDeletion(ctx context.Context) error {
 
 	log.Printf("Pod %q is deleted", podFullName)
 	return nil
+}
+
+func (c *Checkup) cleanupPod() {
+	const setupCleanupTimeout = 30 * time.Second
+
+	log.Printf("setup failed, cleanup Pod '%s/%s'", c.trafficGeneratorPod.Namespace, c.trafficGeneratorPod.Name)
+	delCtx, cancel := context.WithTimeout(context.Background(), setupCleanupTimeout)
+	defer cancel()
+	_ = c.deletePod(delCtx)
+
+	if derr := c.waitForPodDeletion(delCtx); derr != nil {
+		log.Printf("Failed to cleanup Pod '%s/%s': %v", c.trafficGeneratorPod.Namespace, c.trafficGeneratorPod.Name, derr)
+	}
 }
 
 func ObjectFullName(namespace, name string) string {

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -90,6 +90,8 @@ func TestSetupShouldFail(t *testing.T) {
 		testCheckup := checkup.New(testClient, testNamespace, testConfig, executorStub{})
 
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedVMICreationFailure.Error())
+		assert.Empty(t, testClient.createdVMIs)
+		assert.Empty(t, testClient.createdPods)
 	})
 
 	t.Run("when wait for VMI to boot fails", func(t *testing.T) {
@@ -101,6 +103,8 @@ func TestSetupShouldFail(t *testing.T) {
 		testCheckup := checkup.New(testClient, testNamespace, testConfig, executorStub{})
 
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedVMIReadFailure.Error())
+		assert.Empty(t, testClient.createdVMIs)
+		assert.Empty(t, testClient.createdPods)
 	})
 
 	t.Run("when Pod creation fails", func(t *testing.T) {
@@ -112,6 +116,8 @@ func TestSetupShouldFail(t *testing.T) {
 		testCheckup := checkup.New(testClient, testNamespace, testConfig, executorStub{})
 
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedPodCreationFailure.Error())
+		assert.Empty(t, testClient.createdVMIs)
+		assert.Empty(t, testClient.createdPods)
 	})
 
 	t.Run("when wait Pod Running fails on read", func(t *testing.T) {
@@ -123,6 +129,8 @@ func TestSetupShouldFail(t *testing.T) {
 		testCheckup := checkup.New(testClient, testNamespace, testConfig, executorStub{})
 
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedPodReadFailure.Error())
+		assert.Empty(t, testClient.createdVMIs)
+		assert.Empty(t, testClient.createdPods)
 	})
 }
 


### PR DESCRIPTION
Currently, teardown does not happen in case a setup failure occurs.

The VMI and pod are owned by the checkup, so k8s will garbage collect them when the checkup will be deleted [1].

Add explicit cleanup of the VMI and the pod.

Based on kiagnose PR kiagnose/kiagnose#239

[1] https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/