### PR TITLE
Makefile: Make checkup and traffic-gen independent

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,3 +46,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Build checkup image
         run: make build
+  build-traffic-gen:
+    name: Build traffic generator image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Build traffic generator image
+        run: make build-traffic-gen

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,5 +23,11 @@ jobs:
       - name: Login to quay.io
         run:
           ${CRI_BIN} login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
-      - name: Build and push image
-        run: make build push
+      - name: Build checkup image
+        run: make build
+      - name: Build traffic-gen image
+        run: make build-traffic-gen
+      - name: Push checkup image
+        run: make push
+      - name: Push traffic-gen image
+        run: make push-traffic-gen

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all: check build
 
 check: lint test/unit
 
-build: build-traffic-gen
+build:
 	mkdir -p $(CURDIR)/_go-cache
 	$(CRI_BIN) run --rm \
 	           --volume $(CURDIR):$(CURDIR):Z \
@@ -40,7 +40,7 @@ build: build-traffic-gen
 	$(CRI_BIN) build --build-arg BASE_IMAGE_TAG=$(CRI_BUILD_BASE_IMAGE_TAG) . -t $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: build
 
-push: push-traffic-gen
+push:
 	$(CRI_BIN) push $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 	$(CRI_BIN) tag $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG) $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_GIT_TAG)
 	$(CRI_BIN) push $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_GIT_TAG)


### PR DESCRIPTION
Currently, the checkup image `build` and `push` targets are dependent on the traffic generator image matching targets.

This dependency disables the ability to build or push only the checkup image.

Make the `build` and `push` targets of the checkup image independent of the traffic generator image targets.