### PR TITLE
checkup: Reduce Hugepage demand in checkup objects

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -420,6 +420,8 @@ func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 		CPUSocketsCount   = 1
 		CPUCoresCount     = 4
 		CPUTreadsCount    = 2
+		hugePageSize      = "1Gi"
+		guestMemory       = "4Gi"
 		rootDiskName      = "rootdisk"
 		cloudInitDiskName = "cloudinitdisk"
 		eastNetworkName   = "nic-east"
@@ -440,8 +442,7 @@ func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 		vmi.WithMultusNetwork(westNetworkName, checkupConfig.NetworkAttachmentDefinitionName),
 		vmi.WithNetworkInterfaceMultiQueue(),
 		vmi.WithRandomNumberGenerator(),
-		vmi.WithHugePages(),
-		vmi.WithMemoryRequest("8Gi"),
+		vmi.WithMemory(hugePageSize, guestMemory),
 		vmi.WithTerminationGracePeriodSeconds(terminationGracePeriodSeconds),
 		vmi.WithNodeSelector(checkupConfig.DPDKNodeLabelSelector),
 		vmi.WithContainerDisk(rootDiskName, checkupConfig.VMContainerDiskImage),

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -457,7 +457,7 @@ func newTrafficGeneratorPod(checkupConfig config.Config, secondaryNetworkRequest
 		trafficGeneratorServiceAccountName     = "dpdk-checkup-traffic-gen-sa"
 		trafficGeneratorPodCPUCount            = 8
 		trafficGeneratorPodNumOfNonTrafficCPUs = 2
-		trafficGeneratorPodHugepagesCount      = "8Gi"
+		trafficGeneratorPodHugepagesCount      = "1Gi"
 		terminationGracePeriodSeconds          = int64(0)
 
 		portBandwidthParamName     = "PORT_BANDWIDTH_GB"

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -154,20 +154,12 @@ func WithRandomNumberGenerator() Option {
 	}
 }
 
-func WithHugePages() Option {
+func WithMemory(hugePageSize, guestMemory string) Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		guestMemoryQuantity := resource.MustParse(guestMemory)
 		vmi.Spec.Domain.Memory = &kvcorev1.Memory{
-			Hugepages: &kvcorev1.Hugepages{PageSize: "1Gi"},
-		}
-	}
-}
-
-func WithMemoryRequest(memory string) Option {
-	return func(vmi *kvcorev1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Resources = kvcorev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse(memory),
-			},
+			Hugepages: &kvcorev1.Hugepages{PageSize: hugePageSize},
+			Guest:     &guestMemoryQuantity,
 		}
 	}
 }

--- a/vm/scripts/customize-vm
+++ b/vm/scripts/customize-vm
@@ -20,7 +20,7 @@
 systemctl disable NetworkManager-wait-online
 systemctl disable sshd
 
-grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=8 isolcpus=2-7"
+grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1 isolcpus=2-7"
 
 echo  isolated_cores=2-7 > /etc/tuned/cpu-partitioning-variables.conf
 tuned-adm profile cpu-partitioning


### PR DESCRIPTION
The current checkup request 8 hugepages of size 1Gi on each end of the checkup (the traffic generator pod and the DPDK checkup VMI).
This request is unnecessarily big and means we can't run the checkup on smaller clusters.
Reducing the amount to 1 Hugepages on the traffic generator side
Reducing the amount to 4 Hugepages DPDK VMI side (which currently gives off only 1 allocated).