### PR TITLE
Executor: Add podExecuteClient interface

### DIFF
--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -41,6 +41,10 @@ type vmiSerialConsoleClient interface {
 	VMISerialConsole(namespace, name string, timeout time.Duration) (kubecli.StreamInterface, error)
 }
 
+type podExecuteClient interface {
+	ExecuteCommandOnPod(ctx context.Context, namespace, name, containerName string, command []string) (stdout, stderr string, err error)
+}
+
 type testPmdPortStats struct {
 	RXPackets int64
 	RXDropped int64
@@ -61,7 +65,7 @@ const (
 
 type Executor struct {
 	client                           vmiSerialConsoleClient
-	podClient                        trex.PodExecuteClient
+	podClient                        podExecuteClient
 	namespace                        string
 	vmiUsername                      string
 	vmiPassword                      string
@@ -76,7 +80,7 @@ type Executor struct {
 
 const testpmdPrompt = "testpmd> "
 
-func New(client vmiSerialConsoleClient, podClient trex.PodExecuteClient, namespace string, cfg config.Config) Executor {
+func New(client vmiSerialConsoleClient, podClient podExecuteClient, namespace string, cfg config.Config) Executor {
 	return Executor{
 		client:                           client,
 		podClient:                        podClient,

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -31,19 +31,19 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-type PodExecuteClient interface {
+type podExecuteClient interface {
 	ExecuteCommandOnPod(ctx context.Context, namespace, name, containerName string, command []string) (stdout, stderr string, err error)
 }
 
 type trexClient struct {
-	podClient            PodExecuteClient
+	podClient            podExecuteClient
 	namespace            string
 	name                 string
 	containerName        string
 	verbosePrintsEnabled bool
 }
 
-func NewClient(client PodExecuteClient, namespace, name, containerName string, verbosePrintsEnabled bool) trexClient {
+func NewClient(client podExecuteClient, namespace, name, containerName string, verbosePrintsEnabled bool) trexClient {
 	return trexClient{
 		podClient:            client,
 		namespace:            namespace,


### PR DESCRIPTION
Currently, the `executor` package depends on the `trex.PodExecuteClient` interface.
This makes a high-level package depend on the implementation of a lower-level package [1].

Add `podExecuteClient` interface to the `executor` package.
Unexport `trex.PodExecuteClient`.

Tested against an OpenShift Virtualization 4.14 cluster.

[1] https://en.wikipedia.org/wiki/Dependency_inversion_principle