### PR TITLE
[traffic-gen-in-vm] Enable CI on traffic-gen-in-vm branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - 'release-**'
+      - traffic-gen-in-vm
   pull_request:
     branches:
       - main
       - 'release-**'
+      - traffic-gen-in-vm
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - traffic-gen-in-vm
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/vm_containerdisk.yaml
+++ b/.github/workflows/vm_containerdisk.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release-**'
+      - traffic-gen-in-vm
     paths:
       - 'vm/**'
 

--- a/.github/workflows/vm_containerdisk_publish.yaml
+++ b/.github/workflows/vm_containerdisk_publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - traffic-gen-in-vm
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
Currently, the CI is running when creating a PR or pushing to the `main` or release branches.

In order to enable work on the development branch, enable the CI flow on it.