### PR TITLE
E2E: Fix output fields assertions

### DIFF
--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -105,9 +105,9 @@ var _ = Describe("Execute the checkup Job", func() {
 		Expect(configMap.Data).NotTo(BeNil())
 		Expect(configMap.Data["status.succeeded"]).To(Equal("true"), fmt.Sprintf("should succeed %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.failureReason"]).To(BeEmpty(), fmt.Sprintf("should be empty %+v", prettifyData(configMap.Data)))
-		Expect(configMap.Data["status.trafficGeneratorNode"]).ToNot(BeEmpty(),
+		Expect(configMap.Data["status.result.trafficGeneratorNode"]).ToNot(BeEmpty(),
 			fmt.Sprintf("trafficGeneratorNode should not be empty %+v", prettifyData(configMap.Data)))
-		Expect(configMap.Data["status.DPDKVMNode"]).ToNot(BeEmpty(),
+		Expect(configMap.Data["status.result.DPDKVMNode"]).ToNot(BeEmpty(),
 			fmt.Sprintf("DPDKVMNode should not be empty %+v", prettifyData(configMap.Data)))
 	})
 })


### PR DESCRIPTION
Currently, the assertions that the following fields are not empty, are broken:

1. `status.result.trafficGeneratorNode`
2. `status.result.DPDKVMNode`

We haven't seen the above assertions failure,
because the checkup constantly fails due to OCP bugs.