### PR TITLE
[traffic-gen-in-vm] Refactor the checkup package

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -70,7 +70,7 @@ func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config
 		client:       client,
 		namespace:    namespace,
 		params:       checkupConfig,
-		vmiUnderTest: newDPDKVMI(checkupConfig),
+		vmiUnderTest: newVMIUnderTest(checkupConfig),
 		executor:     executor,
 	}
 }
@@ -254,7 +254,7 @@ func randomizeName(prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, k8srand.String(randomStringLen))
 }
 
-func newDPDKVMI(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
+func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 	const (
 		CPUSocketsCount   = 1
 		CPUCoresCount     = 4

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -48,7 +48,7 @@ type kubeVirtVMIClient interface {
 }
 
 type testExecutor interface {
-	Execute(ctx context.Context, vmiName string) (status.Results, error)
+	Execute(ctx context.Context, vmiUnderTestName string) (status.Results, error)
 }
 
 type Checkup struct {

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -79,7 +79,7 @@ func (c *Checkup) Setup(ctx context.Context) (setupErr error) {
 	const errMessagePrefix = "setup"
 	var err error
 
-	if err = c.createVMI(ctx); err != nil {
+	if err = c.createVMI(ctx, c.vmiUnderTest); err != nil {
 		return fmt.Errorf("%s: %w", errMessagePrefix, err)
 	}
 	defer func() {
@@ -144,16 +144,11 @@ func (c *Checkup) Results() status.Results {
 	return c.results
 }
 
-func (c *Checkup) createVMI(ctx context.Context) error {
-	log.Printf("Creating VMI %q...", ObjectFullName(c.namespace, c.vmiUnderTest.Name))
+func (c *Checkup) createVMI(ctx context.Context, vmiToCreate *kvcorev1.VirtualMachineInstance) error {
+	log.Printf("Creating VMI %q...", ObjectFullName(c.namespace, vmiToCreate.Name))
 
-	var err error
-	c.vmiUnderTest, err = c.client.CreateVirtualMachineInstance(ctx, c.namespace, c.vmiUnderTest)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := c.client.CreateVirtualMachineInstance(ctx, c.namespace, vmiToCreate)
+	return err
 }
 
 func (c *Checkup) waitForVMIToBoot(ctx context.Context, name string) (*kvcorev1.VirtualMachineInstance, error) {

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -61,7 +61,7 @@ type Checkup struct {
 }
 
 const (
-	VMINamePrefix          = "dpdk-vmi"
+	VMIUnderTestNamePrefix = "vmi-under-test"
 	DPDKCheckupUIDLabelKey = "kubevirt-dpdk-checkup/uid"
 )
 
@@ -280,7 +280,7 @@ func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstan
 			checkupConfig.PodUID)}
 	}
 
-	return vmi.New(randomizeName(VMINamePrefix),
+	return vmi.New(randomizeName(VMIUnderTestNamePrefix),
 		vmi.WithOwnerReference(checkupConfig.PodName, checkupConfig.PodUID),
 		vmi.WithLabels(labels),
 		vmi.WithAffinity(affinity),

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -264,8 +264,8 @@ func (es executorStub) Execute(_ context.Context, vmiUnderTestName string) (stat
 func newTestConfig() config.Config {
 	trafficGeneratorEastHWAddress, _ := net.ParseMAC(trafficGeneratorEastMacAddress)
 	trafficGeneratorWestHWAddress, _ := net.ParseMAC(trafficGeneratorWestMacAddress)
-	dpdkEastHWAddress, _ := net.ParseMAC(vmiUnderTestEastMacAddress)
-	dpdkWestHWAddress, _ := net.ParseMAC(vmiUnderTestWestMacAddress)
+	vmiUnderTestEastHWAddress, _ := net.ParseMAC(vmiUnderTestEastMacAddress)
+	vmiUnderTestWestHWAddress, _ := net.ParseMAC(vmiUnderTestWestMacAddress)
 	return config.Config{
 		PodName:                           testPodName,
 		PodUID:                            testPodUID,
@@ -276,8 +276,8 @@ func newTestConfig() config.Config {
 		PortBandwidthGB:                   config.PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress:    trafficGeneratorEastHWAddress,
 		TrafficGeneratorWestMacAddress:    trafficGeneratorWestHWAddress,
-		DPDKEastMacAddress:                dpdkEastHWAddress,
-		DPDKWestMacAddress:                dpdkWestHWAddress,
+		DPDKEastMacAddress:                vmiUnderTestEastHWAddress,
+		DPDKWestMacAddress:                vmiUnderTestWestHWAddress,
 		TestDuration:                      config.TestDurationDefault,
 	}
 }

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -241,7 +241,7 @@ func (cs *clientStub) DeleteVirtualMachineInstance(_ context.Context, namespace,
 
 func (cs *clientStub) VMIName() string {
 	for _, vmi := range cs.createdVMIs {
-		if strings.Contains(vmi.Name, checkup.VMINamePrefix) {
+		if strings.Contains(vmi.Name, checkup.VMIUnderTestNamePrefix) {
 			return vmi.Name
 		}
 	}

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -57,13 +57,13 @@ func TestCheckupShouldSucceed(t *testing.T) {
 
 	assert.NoError(t, testCheckup.Setup(context.Background()))
 
-	vmiName := testClient.VMIName()
-	assert.NotEmpty(t, vmiName)
+	vmiUnderTestName := testClient.VMIName(checkup.VMIUnderTestNamePrefix)
+	assert.NotEmpty(t, vmiUnderTestName)
 
 	assert.NoError(t, testCheckup.Run(context.Background()))
 	assert.NoError(t, testCheckup.Teardown(context.Background()))
 
-	_, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiName)
+	_, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiUnderTestName)
 	assert.ErrorContains(t, err, "not found")
 
 	actualResults := testCheckup.Results()
@@ -149,14 +149,14 @@ func TestRunFailure(t *testing.T) {
 
 	assert.NoError(t, testCheckup.Setup(context.Background()))
 
-	vmiName := testClient.VMIName()
-	assert.NotEmpty(t, vmiName)
+	vmiUnderTestName := testClient.VMIName(checkup.VMIUnderTestNamePrefix)
+	assert.NotEmpty(t, vmiUnderTestName)
 
 	assert.Error(t, expectedExecutionFailure, testCheckup.Run(context.Background()))
 
 	assert.NoError(t, testCheckup.Teardown(context.Background()))
 
-	_, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiName)
+	_, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiUnderTestName)
 	assert.ErrorContains(t, err, "not found")
 
 	actualResults := testCheckup.Results()
@@ -239,9 +239,9 @@ func (cs *clientStub) DeleteVirtualMachineInstance(_ context.Context, namespace,
 	return nil
 }
 
-func (cs *clientStub) VMIName() string {
+func (cs *clientStub) VMIName(namePrefix string) string {
 	for _, vmi := range cs.createdVMIs {
-		if strings.Contains(vmi.Name, checkup.VMIUnderTestNamePrefix) {
+		if strings.Contains(vmi.Name, namePrefix) {
 			return vmi.Name
 		}
 	}

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -46,8 +46,8 @@ const (
 	testNetworkAttachmentDefinitionName = "dpdk-network"
 	trafficGeneratorEastMacAddress      = "DE:AD:BE:EF:00:01"
 	trafficGeneratorWestMacAddress      = "DE:AD:BE:EF:01:00"
-	dpdkEastMacAddress                  = "DE:AD:BE:EF:00:02"
-	dpdkWestMacAddress                  = "DE:AD:BE:EF:02:00"
+	vmiUnderTestEastMacAddress          = "DE:AD:BE:EF:00:02"
+	vmiUnderTestWestMacAddress          = "DE:AD:BE:EF:02:00"
 )
 
 func TestCheckupShouldSucceed(t *testing.T) {
@@ -264,8 +264,8 @@ func (es executorStub) Execute(_ context.Context, vmiUnderTestName string) (stat
 func newTestConfig() config.Config {
 	trafficGeneratorEastHWAddress, _ := net.ParseMAC(trafficGeneratorEastMacAddress)
 	trafficGeneratorWestHWAddress, _ := net.ParseMAC(trafficGeneratorWestMacAddress)
-	dpdkEastHWAddress, _ := net.ParseMAC(dpdkEastMacAddress)
-	dpdkWestHWAddress, _ := net.ParseMAC(dpdkWestMacAddress)
+	dpdkEastHWAddress, _ := net.ParseMAC(vmiUnderTestEastMacAddress)
+	dpdkWestHWAddress, _ := net.ParseMAC(vmiUnderTestWestMacAddress)
 	return config.Config{
 		PodName:                           testPodName,
 		PodUID:                            testPodUID,

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -253,7 +253,7 @@ type executorStub struct {
 	executeErr error
 }
 
-func (es executorStub) Execute(_ context.Context, vmiName string) (status.Results, error) {
+func (es executorStub) Execute(_ context.Context, vmiUnderTestName string) (status.Results, error) {
 	if es.executeErr != nil {
 		return status.Results{}, es.executeErr
 	}

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -91,9 +91,9 @@ func New(client vmiSerialConsoleClient, namespace string, cfg config.Config) Exe
 	}
 }
 
-func (e Executor) Execute(ctx context.Context, vmiName string) (status.Results, error) {
-	if err := console.LoginToCentOS(e.client, e.namespace, vmiName, e.vmiUsername, e.vmiPassword); err != nil {
-		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, vmiName, err)
+func (e Executor) Execute(ctx context.Context, vmiUnderTestName string) (status.Results, error) {
+	if err := console.LoginToCentOS(e.client, e.namespace, vmiUnderTestName, e.vmiUsername, e.vmiPassword); err != nil {
+		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, vmiUnderTestName, err)
 	}
 
 	const (
@@ -102,12 +102,12 @@ func (e Executor) Execute(ctx context.Context, vmiName string) (status.Results, 
 	)
 
 	log.Printf("Starting testpmd in VMI...")
-	if err := e.runTestpmd(vmiName); err != nil {
+	if err := e.runTestpmd(vmiUnderTestName); err != nil {
 		return status.Results{}, err
 	}
 
 	log.Printf("Clearing testpmd stats in VMI...")
-	if err := e.clearStatsTestpmd(vmiName); err != nil {
+	if err := e.clearStatsTestpmd(vmiUnderTestName); err != nil {
 		return status.Results{}, err
 	}
 
@@ -125,7 +125,7 @@ func (e Executor) Execute(ctx context.Context, vmiName string) (status.Results, 
 	log.Printf("get testpmd stats in DPDK VMI...")
 	var testPmdStats [testPmdPortStatsSize]testPmdPortStats
 	var err error
-	if testPmdStats, err = e.getStatsTestpmd(vmiName); err != nil {
+	if testPmdStats, err = e.getStatsTestpmd(vmiUnderTestName); err != nil {
 		return status.Results{}, err
 	}
 	results.DPDKPacketsRxDropped = testPmdStats[testPmdPortStatsSummary].RXDropped


### PR DESCRIPTION
Currently, the checkup creates a single VMI object that represents the VMI under test.

Refactor the `checkup` package so it would be easier for follow-up PRs to add the traffic generator VMI.

Tested against an OpenShift Virtualization 4.14 cluster.