### PR TITLE
[traffic-gen-in-vm] VM under test, image: Fix wrong PCI addresses

### DIFF
--- a/vms/vm-under-test/scripts/first-boot
+++ b/vms/vm-under-test/scripts/first-boot
@@ -17,8 +17,8 @@
 # Copyright 2023 Red Hat, Inc.
 #
 
-driverctl set-override 0000:08:00.0 vfio-pci
-driverctl set-override 0000:09:00.0 vfio-pci
+driverctl set-override 0000:06:00.0 vfio-pci
+driverctl set-override 0000:07:00.0 vfio-pci
 
 mkdir /mnt/huge
 mount /mnt/huge --source nodev -t hugetlbfs -o pagesize=1GB


### PR DESCRIPTION
Currently, the VM under test has two SR-IOV NICs configured with static pre-defined PCI addresses.

The above PCI addresses are set in advanced when the containerDisk image is built.

The checkup assumes that these PCI addresses has a certain pre-defined value when it configures and executes `testpmd`.

In PR #126 there was a request [1] to change the PCI addresses of the SR-IOV NICs in the traffic generator image.

It was mistakenly changed in the image of the VM under test [2].
The above change caused problems with `testpmd` which in turn caused the E2E test to fail.

Restore the previous PCI addresses.

[1] https://github.com/kiagnose/kubevirt-dpdk-checkup/pull/126#discussion_r1259628429
[2] https://github.com/kiagnose/kubevirt-dpdk-checkup/compare/3475a2212740c591f9865c71aac2a3c09bd53c2c..2ddac9bac2db7bc90c75bbe8e04cf1a809d37839