### PR TITLE
[traffic-gen-in-vm] Checkup: Move low-level VMI building logic to vmi package

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	k8scorev1 "k8s.io/api/core/v1"
@@ -234,17 +233,6 @@ func ObjectFullName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
-func CloudInit(username, password string) string {
-	sb := strings.Builder{}
-	sb.WriteString("#cloud-config\n")
-	sb.WriteString(fmt.Sprintf("user: %s\n", username))
-	sb.WriteString(fmt.Sprintf("password: %s\n", password))
-	sb.WriteString("chpasswd:\n")
-	sb.WriteString("  expire: false")
-
-	return sb.String()
-}
-
 func randomizeName(prefix string) string {
 	const randomStringLen = 5
 
@@ -295,7 +283,7 @@ func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstan
 		vmi.WithTerminationGracePeriodSeconds(terminationGracePeriodSeconds),
 		vmi.WithContainerDisk(rootDiskName, checkupConfig.VMContainerDiskImage),
 		vmi.WithVirtIODisk(rootDiskName),
-		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword)),
+		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, vmi.CloudInit(config.VMIUsername, config.VMIPassword)),
 		vmi.WithVirtIODisk(cloudInitDiskName),
 	)
 }

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -27,7 +27,6 @@ import (
 
 	k8scorev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	k8srand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	kvcorev1 "kubevirt.io/api/core/v1"
@@ -233,12 +232,6 @@ func ObjectFullName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
-func randomizeName(prefix string) string {
-	const randomStringLen = 5
-
-	return fmt.Sprintf("%s-%s", prefix, k8srand.String(randomStringLen))
-}
-
 func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
 	const (
 		CPUSocketsCount   = 1
@@ -265,7 +258,7 @@ func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstan
 			checkupConfig.PodUID)}
 	}
 
-	return vmi.New(randomizeName(VMIUnderTestNamePrefix),
+	return vmi.New(vmi.RandomizeName(VMIUnderTestNamePrefix),
 		vmi.WithOwnerReference(checkupConfig.PodName, checkupConfig.PodUID),
 		vmi.WithLabels(labels),
 		vmi.WithAffinity(affinity),

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -60,7 +60,6 @@ type Checkup struct {
 
 const (
 	VMIUnderTestNamePrefix = "vmi-under-test"
-	DPDKCheckupUIDLabelKey = "kubevirt-dpdk-checkup/uid"
 )
 
 func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config, executor testExecutor) *Checkup {
@@ -248,13 +247,13 @@ func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstan
 	)
 
 	labels := map[string]string{
-		DPDKCheckupUIDLabelKey: checkupConfig.PodUID,
+		vmi.DPDKCheckupUIDLabelKey: checkupConfig.PodUID,
 	}
 	var affinity *k8scorev1.Affinity
 	if checkupConfig.DPDKNodeLabelSelector != "" {
 		affinity = &k8scorev1.Affinity{NodeAffinity: kaffinity.NewRequiredNodeAffinity(checkupConfig.DPDKNodeLabelSelector)}
 	} else {
-		affinity = &k8scorev1.Affinity{PodAntiAffinity: kaffinity.NewPreferredPodAntiAffinity(DPDKCheckupUIDLabelKey,
+		affinity = &k8scorev1.Affinity{PodAntiAffinity: kaffinity.NewPreferredPodAntiAffinity(vmi.DPDKCheckupUIDLabelKey,
 			checkupConfig.PodUID)}
 	}
 

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -165,17 +165,6 @@ func TestRunFailure(t *testing.T) {
 	assert.Equal(t, expectedResults, actualResults)
 }
 
-func TestCloudInitString(t *testing.T) {
-	actualString := checkup.CloudInit("user", "password")
-	expectedString := `#cloud-config
-user: user
-password: password
-chpasswd:
-  expire: false`
-
-	assert.Equal(t, expectedString, actualString)
-}
-
 type clientStub struct {
 	createdVMIs        map[string]*kvcorev1.VirtualMachineInstance
 	vmiCreationFailure error

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	kvcorev1 "kubevirt.io/api/core/v1"
 )
 
@@ -248,6 +250,12 @@ func CloudInit(username, password string) string {
 	sb.WriteString("  expire: false")
 
 	return sb.String()
+}
+
+func RandomizeName(prefix string) string {
+	const randomStringLen = 5
+
+	return fmt.Sprintf("%s-%s", prefix, rand.String(randomStringLen))
 }
 
 func Pointer[T any](v T) *T {

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -20,6 +20,9 @@
 package vmi
 
 import (
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -234,6 +237,17 @@ func WithAffinity(affinity *corev1.Affinity) Option {
 			vmi.Spec.Affinity = affinity
 		}
 	}
+}
+
+func CloudInit(username, password string) string {
+	sb := strings.Builder{}
+	sb.WriteString("#cloud-config\n")
+	sb.WriteString(fmt.Sprintf("user: %s\n", username))
+	sb.WriteString(fmt.Sprintf("password: %s\n", password))
+	sb.WriteString("chpasswd:\n")
+	sb.WriteString("  expire: false")
+
+	return sb.String()
 }
 
 func Pointer[T any](v T) *T {

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -50,6 +50,21 @@ const DPDKCheckupUIDLabelKey = "kubevirt-dpdk-checkup/uid"
 
 const Disable = "disable"
 
+type DPDKVMIConfig struct {
+	NamePrefix                      string
+	OwnerName                       string
+	OwnerUID                        string
+	Affinity                        *corev1.Affinity
+	ContainerDiskImage              string
+	NetworkAttachmentDefinitionName string
+	NICEastMACAddress               string
+	NICEastPCIAddress               string
+	NICWestMACAddress               string
+	NICWestPCIAddress               string
+	Username                        string
+	Password                        string
+}
+
 type Option func(vmi *kvcorev1.VirtualMachineInstance)
 
 func New(name string, options ...Option) *kvcorev1.VirtualMachineInstance {

--- a/pkg/internal/checkup/vmi/vmi.go
+++ b/pkg/internal/checkup/vmi/vmi.go
@@ -46,6 +46,8 @@ const (
 	CRIOIRQLoadBalancingAnnotation = "irq-load-balancing.crio.io"
 )
 
+const DPDKCheckupUIDLabelKey = "kubevirt-dpdk-checkup/uid"
+
 const Disable = "disable"
 
 type Option func(vmi *kvcorev1.VirtualMachineInstance)

--- a/pkg/internal/checkup/vmi/vmi_test.go
+++ b/pkg/internal/checkup/vmi/vmi_test.go
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vmi_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/vmi"
+)
+
+func TestCloudInitString(t *testing.T) {
+	actualString := vmi.CloudInit("user", "password")
+	expectedString := `#cloud-config
+user: user
+password: password
+chpasswd:
+  expire: false`
+
+	assert.Equal(t, expectedString, actualString)
+}


### PR DESCRIPTION
Currently, the logic that builds the VMI-under-test's spec is located at `checkup.go`.
The above logic is in a lower level of abstraction than checkup.

Move the low-level logic to the `vmi` package, while keeping the high-level logic at checkup.
This will allow a follow-up PR to easily add the traffic generator VMI.

A follow-up PR could also un-export the internal entities of the `vmi` package.

