### PR TITLE
[traffic-gen-in-vm] Move affinity calculation to vmi package

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -31,7 +31,6 @@ import (
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 
-	kaffinity "github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/affinity"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/vmi"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/config"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/status"
@@ -235,11 +234,11 @@ func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstan
 	var affinity *k8scorev1.Affinity
 	if checkupConfig.DPDKNodeLabelSelector != "" {
 		affinity = &k8scorev1.Affinity{
-			NodeAffinity: kaffinity.NewRequiredNodeAffinity(checkupConfig.DPDKNodeLabelSelector),
+			NodeAffinity: vmi.NewRequiredNodeAffinity(checkupConfig.DPDKNodeLabelSelector),
 		}
 	} else {
 		affinity = &k8scorev1.Affinity{
-			PodAntiAffinity: kaffinity.NewPreferredPodAntiAffinity(
+			PodAntiAffinity: vmi.NewPreferredPodAntiAffinity(
 				vmi.DPDKCheckupUIDLabelKey,
 				checkupConfig.PodUID,
 			),

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -231,25 +231,11 @@ func ObjectFullName(namespace, name string) string {
 }
 
 func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
-	var affinity *k8scorev1.Affinity
-	if checkupConfig.DPDKNodeLabelSelector != "" {
-		affinity = &k8scorev1.Affinity{
-			NodeAffinity: vmi.NewRequiredNodeAffinity(checkupConfig.DPDKNodeLabelSelector),
-		}
-	} else {
-		affinity = &k8scorev1.Affinity{
-			PodAntiAffinity: vmi.NewPreferredPodAntiAffinity(
-				vmi.DPDKCheckupUIDLabelKey,
-				checkupConfig.PodUID,
-			),
-		}
-	}
-
 	vmiConfig := vmi.DPDKVMIConfig{
 		NamePrefix:                      VMIUnderTestNamePrefix,
 		OwnerName:                       checkupConfig.PodName,
 		OwnerUID:                        checkupConfig.PodUID,
-		Affinity:                        affinity,
+		Affinity:                        vmi.Affinity(checkupConfig.DPDKNodeLabelSelector, checkupConfig.PodUID),
 		ContainerDiskImage:              checkupConfig.VMContainerDiskImage,
 		NetworkAttachmentDefinitionName: checkupConfig.NetworkAttachmentDefinitionName,
 		NICEastMACAddress:               checkupConfig.DPDKEastMacAddress.String(),

--- a/pkg/internal/checkup/vmi/affinity.go
+++ b/pkg/internal/checkup/vmi/affinity.go
@@ -27,17 +27,17 @@ import (
 func Affinity(nodeName, ownerUID string) *k8scorev1.Affinity {
 	var affinity k8scorev1.Affinity
 	if nodeName != "" {
-		affinity.NodeAffinity = NewRequiredNodeAffinity(nodeName)
+		affinity.NodeAffinity = newRequiredNodeAffinity(nodeName)
 	} else {
-		affinity.PodAntiAffinity = NewPreferredPodAntiAffinity(DPDKCheckupUIDLabelKey, ownerUID)
+		affinity.PodAntiAffinity = newPreferredPodAntiAffinity(DPDKCheckupUIDLabelKey, ownerUID)
 	}
 
 	return &affinity
 }
 
-// NewRequiredNodeAffinity returns new node affinity with node selector of the given node name.
+// newRequiredNodeAffinity returns new node affinity with node selector of the given node name.
 // Adding it to a VMI will make sure it will schedule on the given node name.
-func NewRequiredNodeAffinity(nodeName string) *k8scorev1.NodeAffinity {
+func newRequiredNodeAffinity(nodeName string) *k8scorev1.NodeAffinity {
 	req := k8scorev1.NodeSelectorRequirement{
 		Key:      k8scorev1.LabelHostname,
 		Operator: k8scorev1.NodeSelectorOpIn,
@@ -55,9 +55,9 @@ func NewRequiredNodeAffinity(nodeName string) *k8scorev1.NodeAffinity {
 	}
 }
 
-// NewPreferredPodAntiAffinity returns new pod anti-affinity with label selector of the given label key and value.
+// newPreferredPodAntiAffinity returns new pod anti-affinity with label selector of the given label key and value.
 // Adding it to a VMI will make sure it won't schedule on the same node as other VMIs with the given label.
-func NewPreferredPodAntiAffinity(labelKey, labelVal string) *k8scorev1.PodAntiAffinity {
+func newPreferredPodAntiAffinity(labelKey, labelVal string) *k8scorev1.PodAntiAffinity {
 	req := k8smetav1.LabelSelectorRequirement{
 		Operator: k8smetav1.LabelSelectorOpIn,
 		Key:      labelKey,

--- a/pkg/internal/checkup/vmi/affinity.go
+++ b/pkg/internal/checkup/vmi/affinity.go
@@ -17,7 +17,7 @@
  *
  */
 
-package affinity
+package vmi
 
 import (
 	k8scorev1 "k8s.io/api/core/v1"

--- a/pkg/internal/checkup/vmi/affinity.go
+++ b/pkg/internal/checkup/vmi/affinity.go
@@ -24,6 +24,17 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func Affinity(nodeName, ownerUID string) *k8scorev1.Affinity {
+	var affinity k8scorev1.Affinity
+	if nodeName != "" {
+		affinity.NodeAffinity = NewRequiredNodeAffinity(nodeName)
+	} else {
+		affinity.PodAntiAffinity = NewPreferredPodAntiAffinity(DPDKCheckupUIDLabelKey, ownerUID)
+	}
+
+	return &affinity
+}
+
 // NewRequiredNodeAffinity returns new node affinity with node selector of the given node name.
 // Adding it to a VMI will make sure it will schedule on the given node name.
 func NewRequiredNodeAffinity(nodeName string) *k8scorev1.NodeAffinity {

--- a/pkg/internal/checkup/vmi/affinity_test.go
+++ b/pkg/internal/checkup/vmi/affinity_test.go
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vmi_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	k8scorev1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/vmi"
+)
+
+func TestAffinityCalculation(t *testing.T) {
+	const ownerUID = "123"
+
+	t.Run("When node affinity is expected", func(t *testing.T) {
+		nodeName := "node01"
+
+		actualAffinity := vmi.Affinity(nodeName, ownerUID)
+
+		expectedAffinity := &k8scorev1.Affinity{
+			NodeAffinity: &k8scorev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &k8scorev1.NodeSelector{
+					NodeSelectorTerms: []k8scorev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []k8scorev1.NodeSelectorRequirement{
+								{
+									Key:      k8scorev1.LabelHostname,
+									Operator: k8scorev1.NodeSelectorOpIn,
+									Values:   []string{nodeName}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, expectedAffinity, actualAffinity)
+	})
+
+	t.Run("When pod anti-affinity is expected", func(t *testing.T) {
+		var nodeName string
+
+		actualAffinity := vmi.Affinity(nodeName, ownerUID)
+
+		expectedAffinity := &k8scorev1.Affinity{
+			PodAntiAffinity: &k8scorev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []k8scorev1.WeightedPodAffinityTerm{
+					{
+						Weight: 1,
+						PodAffinityTerm: k8scorev1.PodAffinityTerm{
+							TopologyKey: k8scorev1.LabelHostname,
+							LabelSelector: &k8smetav1.LabelSelector{
+								MatchExpressions: []k8smetav1.LabelSelectorRequirement{
+									{
+										Operator: k8smetav1.LabelSelectorOpIn,
+										Key:      vmi.DPDKCheckupUIDLabelKey,
+										Values:   []string{ownerUID},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, expectedAffinity, actualAffinity)
+	})
+}


### PR DESCRIPTION
Currently, the affinity calculation logic of the VMI under test, is located
under `checkup.go`.

This logic is going to be shared between the VMI under test and the
traffic generator.

Move the affinity calculation logic to a shared location.
Also add unit tests.