### PR TITLE
[traffic-gen-in-vm] Add traffic gen VMI

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -219,7 +219,7 @@ func (c *Checkup) cleanupVMI(name string) {
 	delCtx, cancel := context.WithTimeout(context.Background(), setupCleanupTimeout)
 	defer cancel()
 
-	_ = c.deleteVMI(delCtx, c.vmiUnderTest.Name)
+	_ = c.deleteVMI(delCtx, name)
 
 	if err := c.waitForVMIDeletion(delCtx, name); err != nil {
 		log.Printf("Failed to wait for VMI %q disposal: %v", vmiFullName, err)

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -60,11 +60,13 @@ func TestCheckupShouldSucceed(t *testing.T) {
 	vmiUnderTestName := testClient.VMIName(checkup.VMIUnderTestNamePrefix)
 	assert.NotEmpty(t, vmiUnderTestName)
 
+	trafficGenName := testClient.VMIName(checkup.TrafficGenNamePrefix)
+	assert.NotEmpty(t, trafficGenName)
+
 	assert.NoError(t, testCheckup.Run(context.Background()))
 	assert.NoError(t, testCheckup.Teardown(context.Background()))
 
-	_, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiUnderTestName)
-	assert.ErrorContains(t, err, "not found")
+	assert.Empty(t, testClient.createdVMIs)
 
 	actualResults := testCheckup.Results()
 	expectedResults := status.Results{}
@@ -156,8 +158,7 @@ func TestRunFailure(t *testing.T) {
 
 	assert.NoError(t, testCheckup.Teardown(context.Background()))
 
-	_, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiUnderTestName)
-	assert.ErrorContains(t, err, "not found")
+	assert.Empty(t, testClient.createdVMIs)
 
 	actualResults := testCheckup.Results()
 	expectedResults := status.Results{}

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -105,6 +105,8 @@ var _ = Describe("Execute the checkup Job", func() {
 		Expect(configMap.Data["status.failureReason"]).To(BeEmpty(), fmt.Sprintf("should be empty %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.result.DPDKVMNode"]).ToNot(BeEmpty(),
 			fmt.Sprintf("DPDKVMNode should not be empty %+v", prettifyData(configMap.Data)))
+		Expect(configMap.Data["status.result.trafficGeneratorNode"]).ToNot(BeEmpty(),
+			fmt.Sprintf("trafficGeneratorNode should not be empty %+v", prettifyData(configMap.Data)))
 	})
 })
 


### PR DESCRIPTION
Add the traffic generator VMI:
Setup:
1. Create it.
2. Wait for it to boot.

Run:
Report the node name on which it was scheduled.

Teardown:
1. Delete it.
2. Wait for it to be deleted.