### PR TITLE
[traffic-gen-in-vm] Refactor executer params

### DIFF
--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -43,9 +43,9 @@ type Executor struct {
 	namespace                        string
 	vmiUsername                      string
 	vmiPassword                      string
-	vmiEastNICPCIAddress             string
+	vmiUnderTestEastNICPCIAddress    string
 	vmiEastEthPeerMACAddress         string
-	vmiWestNICPCIAddress             string
+	vmiUnderTestWestNICPCIAddress    string
 	vmiWestEthPeerMACAddress         string
 	testDuration                     time.Duration
 	verbosePrintsEnabled             bool
@@ -58,9 +58,9 @@ func New(client vmiSerialConsoleClient, namespace string, cfg config.Config) Exe
 		namespace:                        namespace,
 		vmiUsername:                      config.VMIUsername,
 		vmiPassword:                      config.VMIPassword,
-		vmiEastNICPCIAddress:             config.VMIEastNICPCIAddress,
+		vmiUnderTestEastNICPCIAddress:    config.VMIEastNICPCIAddress,
 		vmiEastEthPeerMACAddress:         cfg.TrafficGeneratorEastMacAddress.String(),
-		vmiWestNICPCIAddress:             config.VMIWestNICPCIAddress,
+		vmiUnderTestWestNICPCIAddress:    config.VMIWestNICPCIAddress,
 		vmiWestEthPeerMACAddress:         cfg.TrafficGeneratorWestMacAddress.String(),
 		testDuration:                     cfg.TestDuration,
 		verbosePrintsEnabled:             cfg.Verbose,
@@ -84,8 +84,8 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 		trafficDestPort   = 1
 	)
 
-	testpmdConsole := testpmd.NewTestpmdConsole(e.vmiSerialClient, e.namespace, e.vmiEastNICPCIAddress, e.vmiEastEthPeerMACAddress,
-		e.vmiWestNICPCIAddress, e.vmiWestEthPeerMACAddress, e.verbosePrintsEnabled)
+	testpmdConsole := testpmd.NewTestpmdConsole(e.vmiSerialClient, e.namespace, e.vmiUnderTestEastNICPCIAddress, e.vmiEastEthPeerMACAddress,
+		e.vmiUnderTestWestNICPCIAddress, e.vmiWestEthPeerMACAddress, e.verbosePrintsEnabled)
 
 	log.Printf("Starting testpmd in VMI...")
 	if err := testpmdConsole.Run(vmiUnderTestName); err != nil {

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -44,9 +44,9 @@ type Executor struct {
 	vmiUsername                      string
 	vmiPassword                      string
 	vmiUnderTestEastNICPCIAddress    string
-	vmiEastEthPeerMACAddress         string
+	trafficGenEastMACAddress         string
 	vmiUnderTestWestNICPCIAddress    string
-	vmiWestEthPeerMACAddress         string
+	trafficGenWestMACAddress         string
 	testDuration                     time.Duration
 	verbosePrintsEnabled             bool
 	trafficGeneratorPacketsPerSecond string
@@ -59,9 +59,9 @@ func New(client vmiSerialConsoleClient, namespace string, cfg config.Config) Exe
 		vmiUsername:                      config.VMIUsername,
 		vmiPassword:                      config.VMIPassword,
 		vmiUnderTestEastNICPCIAddress:    config.VMIEastNICPCIAddress,
-		vmiEastEthPeerMACAddress:         cfg.TrafficGeneratorEastMacAddress.String(),
+		trafficGenEastMACAddress:         cfg.TrafficGeneratorEastMacAddress.String(),
 		vmiUnderTestWestNICPCIAddress:    config.VMIWestNICPCIAddress,
-		vmiWestEthPeerMACAddress:         cfg.TrafficGeneratorWestMacAddress.String(),
+		trafficGenWestMACAddress:         cfg.TrafficGeneratorWestMacAddress.String(),
 		testDuration:                     cfg.TestDuration,
 		verbosePrintsEnabled:             cfg.Verbose,
 		trafficGeneratorPacketsPerSecond: cfg.TrafficGeneratorPacketsPerSecond,
@@ -84,8 +84,8 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 		trafficDestPort   = 1
 	)
 
-	testpmdConsole := testpmd.NewTestpmdConsole(e.vmiSerialClient, e.namespace, e.vmiUnderTestEastNICPCIAddress, e.vmiEastEthPeerMACAddress,
-		e.vmiUnderTestWestNICPCIAddress, e.vmiWestEthPeerMACAddress, e.verbosePrintsEnabled)
+	testpmdConsole := testpmd.NewTestpmdConsole(e.vmiSerialClient, e.namespace, e.vmiUnderTestEastNICPCIAddress, e.trafficGenEastMACAddress,
+		e.vmiUnderTestWestNICPCIAddress, e.trafficGenWestMACAddress, e.verbosePrintsEnabled)
 
 	log.Printf("Starting testpmd in VMI...")
 	if err := testpmdConsole.Run(vmiUnderTestName); err != nil {

--- a/pkg/internal/checkup/executor/testpmd/console.go
+++ b/pkg/internal/checkup/executor/testpmd/console.go
@@ -68,12 +68,12 @@ const (
 const testpmdPrompt = "testpmd> "
 
 func NewTestpmdConsole(vmiSerialClient vmiSerialConsoleClient, namespace, vmiUnderTestEastNICPCIAddress,
-	vmiEastEthPeerMACAddress, vmiUnderTestWestNICPCIAddress, vmiWestEthPeerMACAddress string, verbosePrintsEnabled bool) *TestpmdConsole {
+	trafficGenEastMACAddress, vmiUnderTestWestNICPCIAddress, trafficGenWestMACAddress string, verbosePrintsEnabled bool) *TestpmdConsole {
 	return &TestpmdConsole{
 		vmiSerialClient:          vmiSerialClient,
 		namespace:                namespace,
-		vmiEastEthPeerMACAddress: vmiEastEthPeerMACAddress,
-		vmiWestEthPeerMACAddress: vmiWestEthPeerMACAddress,
+		vmiEastEthPeerMACAddress: trafficGenEastMACAddress,
+		vmiWestEthPeerMACAddress: trafficGenWestMACAddress,
 		vmiEastNICPCIAddress:     vmiUnderTestEastNICPCIAddress,
 		vmiWestNICPCIAddress:     vmiUnderTestWestNICPCIAddress,
 		verbosePrintsEnabled:     verbosePrintsEnabled,

--- a/pkg/internal/checkup/executor/testpmd/console.go
+++ b/pkg/internal/checkup/executor/testpmd/console.go
@@ -67,15 +67,15 @@ const (
 
 const testpmdPrompt = "testpmd> "
 
-func NewTestpmdConsole(vmiSerialClient vmiSerialConsoleClient, namespace, vmiEastNICPCIAddress,
-	vmiEastEthPeerMACAddress, vmiWestNICPCIAddress, vmiWestEthPeerMACAddress string, verbosePrintsEnabled bool) *TestpmdConsole {
+func NewTestpmdConsole(vmiSerialClient vmiSerialConsoleClient, namespace, vmiUnderTestEastNICPCIAddress,
+	vmiEastEthPeerMACAddress, vmiUnderTestWestNICPCIAddress, vmiWestEthPeerMACAddress string, verbosePrintsEnabled bool) *TestpmdConsole {
 	return &TestpmdConsole{
 		vmiSerialClient:          vmiSerialClient,
 		namespace:                namespace,
 		vmiEastEthPeerMACAddress: vmiEastEthPeerMACAddress,
 		vmiWestEthPeerMACAddress: vmiWestEthPeerMACAddress,
-		vmiEastNICPCIAddress:     vmiEastNICPCIAddress,
-		vmiWestNICPCIAddress:     vmiWestNICPCIAddress,
+		vmiEastNICPCIAddress:     vmiUnderTestEastNICPCIAddress,
+		vmiWestNICPCIAddress:     vmiUnderTestWestNICPCIAddress,
 		verbosePrintsEnabled:     verbosePrintsEnabled,
 	}
 }


### PR DESCRIPTION
Now that both traffic generator and the "VMI under test" are VMIs, some params are left ambiguous. 
Refactoring params to avoid future confusion.
