### PR TITLE
[traffic-gen-in-vm] Add traffic gen ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ rules:
   - apiGroups: [ "subresources.kubevirt.io" ]
     resources: [ "virtualmachineinstances/console" ]
     verbs: [ "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "create", "delete" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -31,6 +31,7 @@ import (
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/configmap"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/vmi"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/config"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/status"
@@ -42,6 +43,7 @@ type kubeVirtVMIClient interface {
 		vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
 	GetVirtualMachineInstance(ctx context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error)
 	DeleteVirtualMachineInstance(ctx context.Context, namespace, name string) error
+	CreateConfigMap(ctx context.Context, namespace string, configMap *k8scorev1.ConfigMap) (*k8scorev1.ConfigMap, error)
 }
 
 type testExecutor interface {
@@ -49,34 +51,41 @@ type testExecutor interface {
 }
 
 type Checkup struct {
-	client       kubeVirtVMIClient
-	namespace    string
-	params       config.Config
-	vmiUnderTest *kvcorev1.VirtualMachineInstance
-	trafficGen   *kvcorev1.VirtualMachineInstance
-	results      status.Results
-	executor     testExecutor
+	client              kubeVirtVMIClient
+	namespace           string
+	params              config.Config
+	vmiUnderTest        *kvcorev1.VirtualMachineInstance
+	trafficGen          *kvcorev1.VirtualMachineInstance
+	trafficGenConfigMap *k8scorev1.ConfigMap
+	results             status.Results
+	executor            testExecutor
 }
 
 const (
-	VMIUnderTestNamePrefix = "vmi-under-test"
-	TrafficGenNamePrefix   = "dpdk-traffic-gen"
+	VMIUnderTestNamePrefix        = "vmi-under-test"
+	TrafficGenNamePrefix          = "dpdk-traffic-gen"
+	TrafficGenConfigMapNamePrefix = "dpdk-traffic-gen-config"
 )
 
 func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config, executor testExecutor) *Checkup {
 	return &Checkup{
-		client:       client,
-		namespace:    namespace,
-		params:       checkupConfig,
-		vmiUnderTest: newVMIUnderTest(checkupConfig),
-		trafficGen:   newTrafficGen(checkupConfig),
-		executor:     executor,
+		client:              client,
+		namespace:           namespace,
+		params:              checkupConfig,
+		vmiUnderTest:        newVMIUnderTest(checkupConfig),
+		trafficGen:          newTrafficGen(checkupConfig),
+		trafficGenConfigMap: newTrafficGenConfigMap(checkupConfig),
+		executor:            executor,
 	}
 }
 
 func (c *Checkup) Setup(ctx context.Context) (setupErr error) {
 	const errMessagePrefix = "setup"
 	var err error
+
+	if err = c.createTrafficGenCM(ctx); err != nil {
+		return fmt.Errorf("%s: %w", errMessagePrefix, err)
+	}
 
 	if err = c.createVMI(ctx, c.vmiUnderTest); err != nil {
 		return fmt.Errorf("%s: %w", errMessagePrefix, err)
@@ -169,6 +178,13 @@ func (c *Checkup) Results() status.Results {
 	return c.results
 }
 
+func (c *Checkup) createTrafficGenCM(ctx context.Context) error {
+	log.Printf("Creating ConfigMap %q...", ObjectFullName(c.namespace, c.trafficGenConfigMap.Name))
+
+	_, err := c.client.CreateConfigMap(ctx, c.namespace, c.trafficGenConfigMap)
+	return err
+}
+
 func (c *Checkup) createVMI(ctx context.Context, vmiToCreate *kvcorev1.VirtualMachineInstance) error {
 	log.Printf("Creating VMI %q...", ObjectFullName(c.namespace, vmiToCreate.Name))
 
@@ -257,6 +273,10 @@ func (c *Checkup) cleanupVMI(name string) {
 
 func ObjectFullName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+func newTrafficGenConfigMap(checkupConfig config.Config) *k8scorev1.ConfigMap {
+	return configmap.New(TrafficGenConfigMapNamePrefix, checkupConfig.PodName, checkupConfig.PodUID)
 }
 
 func newVMIUnderTest(checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {

--- a/pkg/internal/checkup/configmap/configmap.go
+++ b/pkg/internal/checkup/configmap/configmap.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package configmap
+
+import (
+	k8scorev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func New(name, ownerName, ownerUID string) *k8scorev1.ConfigMap {
+	return &k8scorev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       ownerName,
+					UID:        types.UID(ownerUID),
+				},
+			},
+		},
+	}
+}

--- a/pkg/internal/checkup/configmap/configmap_test.go
+++ b/pkg/internal/checkup/configmap/configmap_test.go
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package configmap_test
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+
+	k8scorev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/configmap"
+)
+
+func TestNew(t *testing.T) {
+	name := "my-cm"
+	ownerName := "my-pod"
+	ownerUID := "1234567890"
+
+	actualConfigMap := configmap.New(name, ownerName, ownerUID)
+
+	expectedConfigMap := &k8scorev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       ownerName,
+					UID:        types.UID(ownerUID),
+				},
+			},
+		},
+		Data: nil,
+	}
+
+	assert.Equal(t, expectedConfigMap, actualConfigMap)
+}

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"time"
 
+	k8scorev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	kvcorev1 "kubevirt.io/api/core/v1"
@@ -66,4 +67,8 @@ func (c *Client) VMISerialConsole(namespace, name string, timeout time.Duration)
 		name,
 		&kubecli.SerialConsoleOptions{ConnectionTimeout: timeout},
 	)
+}
+
+func (c *Client) CreateConfigMap(ctx context.Context, namespace string, configMap *k8scorev1.ConfigMap) (*k8scorev1.ConfigMap, error) {
+	return c.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
 }

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -72,3 +72,7 @@ func (c *Client) VMISerialConsole(namespace, name string, timeout time.Duration)
 func (c *Client) CreateConfigMap(ctx context.Context, namespace string, configMap *k8scorev1.ConfigMap) (*k8scorev1.ConfigMap, error) {
 	return c.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
 }
+
+func (c *Client) DeleteConfigMap(ctx context.Context, namespace, name string) error {
+	return c.CoreV1().ConfigMaps(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -254,6 +254,11 @@ func newKubeVirtDPDKCheckerRole() *rbacv1.Role {
 				Resources: []string{"virtualmachineinstances/console"},
 				Verbs:     []string{"get"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"create", "delete"},
+			},
 		},
 	}
 }


### PR DESCRIPTION
In order to enable the checkup the ability to create a ConfigMap containing the TRex[1] configuration to be attached to the traffic gen VMI, allow the checkup to create and delete a ConfigMap object.

Currently, the ConfigMap is empty and not attached to the traffic gen VMI.
Follow-up PRs will fill up the ConfigMap with TRex configuration files and will attach it to the traffic gen VMI.

Currently, the ConfigMap name is not randomized.
A follow-up PR will add the same random suffix to both VMIs and ConfigMap.

[1] https://trex-tgn.cisco.com/
