### PR TITLE
[traffic-gen-in-vm] Executor: Add login to traffic gen VMI

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -45,7 +45,7 @@ type kubeVirtVMIClient interface {
 }
 
 type testExecutor interface {
-	Execute(ctx context.Context, vmiUnderTestName string) (status.Results, error)
+	Execute(ctx context.Context, vmiUnderTestName, trafficGenVMIName string) (status.Results, error)
 }
 
 type Checkup struct {
@@ -118,7 +118,7 @@ func (c *Checkup) Setup(ctx context.Context) (setupErr error) {
 func (c *Checkup) Run(ctx context.Context) error {
 	var err error
 
-	c.results, err = c.executor.Execute(ctx, c.vmiUnderTest.Name)
+	c.results, err = c.executor.Execute(ctx, c.vmiUnderTest.Name, c.trafficGen.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -360,7 +360,7 @@ type executorStub struct {
 	executeErr error
 }
 
-func (es executorStub) Execute(_ context.Context, vmiUnderTestName string) (status.Results, error) {
+func (es executorStub) Execute(_ context.Context, vmiUnderTestName, trafficGenVMIName string) (status.Results, error) {
 	if es.executeErr != nil {
 		return status.Results{}, es.executeErr
 	}

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -91,9 +91,15 @@ func New(client vmiSerialConsoleClient, namespace string, cfg config.Config) Exe
 	}
 }
 
-func (e Executor) Execute(ctx context.Context, vmiUnderTestName string) (status.Results, error) {
+func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMIName string) (status.Results, error) {
+	log.Printf("Login to VMI under test...")
 	if err := console.LoginToCentOS(e.client, e.namespace, vmiUnderTestName, e.vmiUsername, e.vmiPassword); err != nil {
 		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, vmiUnderTestName, err)
+	}
+
+	log.Printf("Login to traffic generator...")
+	if err := console.LoginToCentOS(e.client, e.namespace, trafficGenVMIName, e.vmiUsername, e.vmiPassword); err != nil {
+		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, trafficGenVMIName, err)
 	}
 
 	const (


### PR DESCRIPTION
In order to operate the TRex application, via the traffic gen's serial console, login to the guest OS.