### PR TITLE
[traffic-gen-in-vm] Attach traffic-gen's ConfigMap to traffic gen VMI

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -70,13 +70,15 @@ func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config
 	const randomStringLen = 5
 	randomSuffix := rand.String(randomStringLen)
 
+	trafficGenCMName := trafficGenConfigMapName(randomSuffix)
+
 	return &Checkup{
 		client:              client,
 		namespace:           namespace,
 		params:              checkupConfig,
 		vmiUnderTest:        newVMIUnderTest(vmiUnderTestName(randomSuffix), checkupConfig),
-		trafficGen:          newTrafficGen(trafficGenName(randomSuffix), checkupConfig),
-		trafficGenConfigMap: newTrafficGenConfigMap(trafficGenConfigMapName(randomSuffix), checkupConfig),
+		trafficGen:          newTrafficGen(trafficGenName(randomSuffix), checkupConfig, trafficGenCMName),
+		trafficGenConfigMap: newTrafficGenConfigMap(trafficGenCMName, checkupConfig),
 		executor:            executor,
 	}
 }

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -65,7 +65,10 @@ func newVMIUnderTest(name string, checkupConfig config.Config) *kvcorev1.Virtual
 	return vmi.New(name, optionsToApply...)
 }
 
-func newTrafficGen(name string, checkupConfig config.Config) *kvcorev1.VirtualMachineInstance {
+func newTrafficGen(name string, checkupConfig config.Config, configMapName string) *kvcorev1.VirtualMachineInstance {
+	const configDiskSerial = "DEADBEEF"
+	const configVolumeName = "trex-config"
+
 	optionsToApply := baseOptions(checkupConfig)
 
 	optionsToApply = append(optionsToApply,
@@ -73,7 +76,12 @@ func newTrafficGen(name string, checkupConfig config.Config) *kvcorev1.VirtualMa
 		vmi.WithSRIOVInterface(eastNetworkName, checkupConfig.TrafficGeneratorEastMacAddress.String(), config.VMIEastNICPCIAddress),
 		vmi.WithSRIOVInterface(westNetworkName, checkupConfig.TrafficGeneratorWestMacAddress.String(), config.VMIWestNICPCIAddress),
 		vmi.WithContainerDisk(rootDiskName, checkupConfig.TrafficGeneratorImage),
-		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword, nil)),
+		vmi.WithCloudInitNoCloudVolume(
+			cloudInitDiskName,
+			CloudInit(config.VMIUsername, config.VMIPassword, trafficGenBootCommands(configDiskSerial)),
+		),
+		vmi.WithConfigMapVolume(configVolumeName, configMapName),
+		vmi.WithConfigMapDisk(configVolumeName, configDiskSerial),
 	)
 
 	return vmi.New(name, optionsToApply...)
@@ -130,4 +138,13 @@ func CloudInit(username, password string, bootCommands []string) string {
 	}
 
 	return sb.String()
+}
+
+func trafficGenBootCommands(configDiskSerial string) []string {
+	const configMountDirectory = "/mnt/app-config"
+
+	return []string{
+		fmt.Sprintf("sudo mkdir %s", configMountDirectory),
+		fmt.Sprintf("sudo mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') %s", configDiskSerial, configMountDirectory),
+	}
 }

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -59,7 +59,7 @@ func newVMIUnderTest(name string, checkupConfig config.Config) *kvcorev1.Virtual
 		vmi.WithSRIOVInterface(eastNetworkName, checkupConfig.DPDKEastMacAddress.String(), config.VMIEastNICPCIAddress),
 		vmi.WithSRIOVInterface(westNetworkName, checkupConfig.DPDKWestMacAddress.String(), config.VMIWestNICPCIAddress),
 		vmi.WithContainerDisk(rootDiskName, checkupConfig.VMContainerDiskImage),
-		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword)),
+		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword, nil)),
 	)
 
 	return vmi.New(name, optionsToApply...)
@@ -73,7 +73,7 @@ func newTrafficGen(name string, checkupConfig config.Config) *kvcorev1.VirtualMa
 		vmi.WithSRIOVInterface(eastNetworkName, checkupConfig.TrafficGeneratorEastMacAddress.String(), config.VMIEastNICPCIAddress),
 		vmi.WithSRIOVInterface(westNetworkName, checkupConfig.TrafficGeneratorWestMacAddress.String(), config.VMIWestNICPCIAddress),
 		vmi.WithContainerDisk(rootDiskName, checkupConfig.TrafficGeneratorImage),
-		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword)),
+		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(config.VMIUsername, config.VMIPassword, nil)),
 	)
 
 	return vmi.New(name, optionsToApply...)
@@ -113,13 +113,21 @@ func Affinity(nodeName, ownerUID string) *k8scorev1.Affinity {
 	return &affinity
 }
 
-func CloudInit(username, password string) string {
+func CloudInit(username, password string, bootCommands []string) string {
 	sb := strings.Builder{}
 	sb.WriteString("#cloud-config\n")
 	sb.WriteString(fmt.Sprintf("user: %s\n", username))
 	sb.WriteString(fmt.Sprintf("password: %s\n", password))
 	sb.WriteString("chpasswd:\n")
-	sb.WriteString("  expire: false")
+	sb.WriteString("  expire: false\n")
+
+	if len(bootCommands) != 0 {
+		sb.WriteString("bootcmd:\n")
+
+		for _, command := range bootCommands {
+			sb.WriteString(fmt.Sprintf("  - %q\n", command))
+		}
+	}
 
 	return sb.String()
 }

--- a/pkg/internal/checkup/vmi/spec.go
+++ b/pkg/internal/checkup/vmi/spec.go
@@ -128,6 +128,17 @@ func WithVirtIODisk(name string) Option {
 	}
 }
 
+func WithConfigMapDisk(name, serial string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks,
+			kvcorev1.Disk{
+				Name:   name,
+				Serial: serial,
+			},
+		)
+	}
+}
+
 func WithSRIOVInterface(name, macAddress, pciAddress string) Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, kvcorev1.Interface{
@@ -196,6 +207,20 @@ func WithContainerDisk(volumeName, imageName string) Option {
 		}
 
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newVolume)
+	}
+}
+
+func WithConfigMapVolume(name, configMapName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, kvcorev1.Volume{
+			Name: name,
+			VolumeSource: kvcorev1.VolumeSource{
+				ConfigMap: &kvcorev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+					Optional:             Pointer(false),
+				},
+			},
+		})
 	}
 }
 

--- a/pkg/internal/checkup/vmi_test.go
+++ b/pkg/internal/checkup/vmi_test.go
@@ -90,12 +90,37 @@ func TestAffinityCalculation(t *testing.T) {
 }
 
 func TestCloudInitString(t *testing.T) {
-	actualString := checkup.CloudInit("user", "password")
-	expectedString := `#cloud-config
+	const username = "user"
+	const password = "password"
+	t.Run("without boot commands", func(t *testing.T) {
+		actualString := checkup.CloudInit(username, password, nil)
+		expectedString := `#cloud-config
 user: user
 password: password
 chpasswd:
-  expire: false`
+  expire: false
+`
 
-	assert.Equal(t, expectedString, actualString)
+		assert.Equal(t, expectedString, actualString)
+	})
+
+	t.Run("with boot commands", func(t *testing.T) {
+		bootCommands := []string{
+			"sudo mkdir /mnt/app-config",
+			"sudo mount /dev/$(lsblk --nodeps -no name,serial | grep DEADBEEF | cut -f1 -d' ') /mnt/app-config",
+		}
+
+		actualString := checkup.CloudInit(username, password, bootCommands)
+		expectedString := `#cloud-config
+user: user
+password: password
+chpasswd:
+  expire: false
+bootcmd:
+  - "sudo mkdir /mnt/app-config"
+  - "sudo mount /dev/$(lsblk --nodeps -no name,serial | grep DEADBEEF | cut -f1 -d' ') /mnt/app-config"
+`
+
+		assert.Equal(t, expectedString, actualString)
+	})
 }


### PR DESCRIPTION
In order to get the Trex configuration, the ConfigMap object generated by the checkup, should be attached to the traffic-gen VMI, and mounted inside the guest [1].

1. Create a volume in the traffic gen VMI, referring to the to the traffic-gen's ConfigMap.
2. Create a disk that refers to the above volume.
3. Using cloud init, mount the above disk to the guest's file system.

The generated ConfigMap is currently empty, until a follow-up PR will fill it up.

~~Based on PR #147, please review only the last three commits.~~

[1] http://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#configmap
