### PR TITLE
[traffic-gen-in-vm] Place TRex config file and scripts

### DIFF
--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -150,5 +150,6 @@ func trafficGenBootCommands(configDiskSerial string) []string {
 		fmt.Sprintf("sudo mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') %s", configDiskSerial, configMountDirectory),
 		fmt.Sprintf("sudo cp %s/%s /etc", configMountDirectory, trex.CfgFileName),
 		fmt.Sprintf("sudo mkdir -p %s", testScriptsDirectory),
+		fmt.Sprintf("sudo cp %s/*.py %s", configMountDirectory, testScriptsDirectory),
 	}
 }

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -26,6 +26,7 @@ import (
 	k8scorev1 "k8s.io/api/core/v1"
 	kvcorev1 "kubevirt.io/api/core/v1"
 
+	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/trex"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/vmi"
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/config"
 )
@@ -146,5 +147,6 @@ func trafficGenBootCommands(configDiskSerial string) []string {
 	return []string{
 		fmt.Sprintf("sudo mkdir %s", configMountDirectory),
 		fmt.Sprintf("sudo mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') %s", configDiskSerial, configMountDirectory),
+		fmt.Sprintf("sudo cp %s/%s /etc", configMountDirectory, trex.CfgFileName),
 	}
 }

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -143,10 +143,12 @@ func CloudInit(username, password string, bootCommands []string) string {
 
 func trafficGenBootCommands(configDiskSerial string) []string {
 	const configMountDirectory = "/mnt/app-config"
+	const testScriptsDirectory = "/opt/tests"
 
 	return []string{
 		fmt.Sprintf("sudo mkdir %s", configMountDirectory),
 		fmt.Sprintf("sudo mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') %s", configDiskSerial, configMountDirectory),
 		fmt.Sprintf("sudo cp %s/%s /etc", configMountDirectory, trex.CfgFileName),
+		fmt.Sprintf("sudo mkdir -p %s", testScriptsDirectory),
 	}
 }


### PR DESCRIPTION
Following PR #149, the traffic-gen ConfigMap contains the TRex configuration file and several Python scripts.
When mounting the disk containing the ConfigMap, the files are read only.

1. Copy the TRex config file to `/etc` in the traffic-gen guest.
2. Create a directory to hold the Python scripts `/opt/tests`.
3. Copy the Python scripts to the above directory.

AFAIU, there is no need to make the Python scripts executable, because they are not executed as standalone scripts,
and do not have a Shebang [1].

[1] https://en.wikipedia.org/wiki/Shebang_(Unix)