### PR TITLE
[traffic-gen-in-vm] Trex, Python scripts: Quote MAC addresses

### DIFF
--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -146,9 +146,9 @@ def register():
 
 func (t Config) GenerateStreamAddrPyFile() string {
 	const streamAddrPyTemplate = `# wild first XL710 mac
-mac_telco0 = %s
+mac_telco0 = %q
 # wild second XL710 mac
-mac_telco1 = %s
+mac_telco1 = %q
 # we don’t care of the IP in this phase
 ip_telco0  = '10.0.0.1'
 ip_telco1 = '10.1.1.1'

--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -98,8 +98,8 @@ func (t Config) GenerateStreamPyFile() string {
 from testpmd_addr import *
 
 # Wild local MACs
-mac_localport0=%s
-mac_localport1=%s
+mac_localport0=%q
+mac_localport1=%q
 
 class STLS1(object):
 

--- a/pkg/internal/checkup/trex/configfiles_test.go
+++ b/pkg/internal/checkup/trex/configfiles_test.go
@@ -63,8 +63,8 @@ func TestGetTestpmdStreamPyFile(t *testing.T) {
 from testpmd_addr import *
 
 # Wild local MACs
-mac_localport0=00:00:00:00:00:00
-mac_localport1=00:00:00:00:00:01
+mac_localport0="00:00:00:00:00:00"
+mac_localport1="00:00:00:00:00:01"
 
 class STLS1(object):
 

--- a/pkg/internal/checkup/trex/configfiles_test.go
+++ b/pkg/internal/checkup/trex/configfiles_test.go
@@ -109,9 +109,9 @@ func TestGetTestpmdStreamAddrPyFile(t *testing.T) {
 	addrPyFile := cfgs.GenerateStreamAddrPyFile()
 
 	const expectedAddrPyFile = `# wild first XL710 mac
-mac_telco0 = 00:00:00:00:00:02
+mac_telco0 = "00:00:00:00:00:02"
 # wild second XL710 mac
-mac_telco1 = 00:00:00:00:00:03
+mac_telco1 = "00:00:00:00:00:03"
 # we don’t care of the IP in this phase
 ip_telco0  = '10.0.0.1'
 ip_telco1 = '10.1.1.1'


### PR DESCRIPTION
Currently, the MAC addresses that are embedded in the output string of `GenerateStreamPyFile()` and `GenerateStreamAddrPyFile()` and are not quoted, thus making the Python interpreter fail.

Surround the MAC addresses in quotes.