### PR TITLE
[traffic-gen-in-vm] Enable TRex execution using systemd

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -293,6 +293,7 @@ func ObjectFullName(namespace, name string) string {
 func newTrafficGenConfigMap(name string, checkupConfig config.Config) *k8scorev1.ConfigMap {
 	trexConfig := trex.NewConfig(checkupConfig)
 	trafficGenConfigData := map[string]string{
+		trex.ExecutionScriptName:        trexConfig.GenerateExecutionScript(),
 		trex.CfgFileName:                trexConfig.GenerateCfgFile(),
 		trex.StreamPyFileName:           trexConfig.GenerateStreamPyFile(),
 		trex.StreamPeerParamsPyFileName: trexConfig.GenerateStreamAddrPyFile(),

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -293,6 +293,7 @@ func ObjectFullName(namespace, name string) string {
 func newTrafficGenConfigMap(name string, checkupConfig config.Config) *k8scorev1.ConfigMap {
 	trexConfig := trex.NewConfig(checkupConfig)
 	trafficGenConfigData := map[string]string{
+		trex.SystemdUnitFileName:        trex.GenerateSystemdUnitFile(),
 		trex.ExecutionScriptName:        trexConfig.GenerateExecutionScript(),
 		trex.CfgFileName:                trexConfig.GenerateCfgFile(),
 		trex.StreamPyFileName:           trexConfig.GenerateStreamPyFile(),

--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -21,6 +21,7 @@ package trex
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/config"
 )
@@ -157,4 +158,13 @@ ip_telco1 = '10.1.1.1'
 		c.DPDKEastMacAddress,
 		c.DPDKWestMacAddress,
 	)
+}
+
+func (c Config) GenerateExecutionScript() string {
+	sb := strings.Builder{}
+
+	sb.WriteString("#!/usr/bin/env bash\n")
+	sb.WriteString(fmt.Sprintf("./t-rex-64 --no-ofed-check --no-scapy-server --no-hw-flow-stat -i -c %s --iom 0\n", c.numOfTrafficCPUs))
+
+	return sb.String()
 }

--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -63,7 +63,7 @@ func NewConfig(cfg config.Config) Config {
 	}
 }
 
-func (t Config) GenerateCfgFile() string {
+func (c Config) GenerateCfgFile() string {
 	const cfgTemplate = `- port_limit: 2
   version: 2
   interfaces:
@@ -85,14 +85,14 @@ func (t Config) GenerateCfgFile() string {
 	return fmt.Sprintf(cfgTemplate,
 		config.VMIEastNICPCIAddress,
 		config.VMIWestNICPCIAddress,
-		t.portBandwidthGB,
-		t.masterCPU,
-		t.latencyCPU,
-		t.trafficCPUs,
+		c.portBandwidthGB,
+		c.masterCPU,
+		c.latencyCPU,
+		c.trafficCPUs,
 	)
 }
 
-func (t Config) GenerateStreamPyFile() string {
+func (c Config) GenerateStreamPyFile() string {
 	const streamPyTemplate = `from trex_stl_lib.api import *
 
 from testpmd_addr import *
@@ -138,13 +138,13 @@ def register():
 `
 
 	return fmt.Sprintf(streamPyTemplate,
-		t.trafficGeneratorEastMacAddress,
-		t.trafficGeneratorWestMacAddress,
-		t.numOfTrafficCPUs,
+		c.trafficGeneratorEastMacAddress,
+		c.trafficGeneratorWestMacAddress,
+		c.numOfTrafficCPUs,
 	)
 }
 
-func (t Config) GenerateStreamAddrPyFile() string {
+func (c Config) GenerateStreamAddrPyFile() string {
 	const streamAddrPyTemplate = `# wild first XL710 mac
 mac_telco0 = %q
 # wild second XL710 mac
@@ -154,7 +154,7 @@ ip_telco0  = '10.0.0.1'
 ip_telco1 = '10.1.1.1'
 `
 	return fmt.Sprintf(streamAddrPyTemplate,
-		t.DPDKEastMacAddress,
-		t.DPDKWestMacAddress,
+		c.DPDKEastMacAddress,
+		c.DPDKWestMacAddress,
 	)
 }

--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -21,6 +21,7 @@ package trex
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/config"
@@ -167,6 +168,21 @@ func (c Config) GenerateExecutionScript() string {
 
 	sb.WriteString("#!/usr/bin/env bash\n")
 	sb.WriteString(fmt.Sprintf("./t-rex-64 --no-ofed-check --no-scapy-server --no-hw-flow-stat -i -c %s --iom 0\n", c.numOfTrafficCPUs))
+
+	return sb.String()
+}
+
+func GenerateSystemdUnitFile() string {
+	sb := strings.Builder{}
+
+	sb.WriteString("[Unit]\n")
+	sb.WriteString("Description=TRex Server\n")
+	sb.WriteString("[Service]\n")
+	sb.WriteString(fmt.Sprintf("WorkingDirectory=%s\n", BinDirectory))
+	sb.WriteString(fmt.Sprintf("ExecStart=%s\n", path.Join(BinDirectory, ExecutionScriptName)))
+	sb.WriteString("Restart=no\n")
+	sb.WriteString("User=root\n")
+	sb.WriteString("Group=root\n")
 
 	return sb.String()
 }

--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -31,6 +31,7 @@ const (
 	StreamPyFileName           = "testpmd.py"
 	StreamPeerParamsPyFileName = "testpmd_addr.py"
 	ExecutionScriptName        = "run_trex_daemon"
+	BinDirectory               = "/opt/trex"
 )
 
 type Config struct {

--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -33,6 +33,7 @@ const (
 	StreamPeerParamsPyFileName = "testpmd_addr.py"
 	ExecutionScriptName        = "run_trex_daemon"
 	BinDirectory               = "/opt/trex"
+	SystemdUnitFileName        = "trex.service"
 )
 
 type Config struct {

--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -30,6 +30,7 @@ const (
 	CfgFileName                = "trex_cfg.yaml"
 	StreamPyFileName           = "testpmd.py"
 	StreamPeerParamsPyFileName = "testpmd_addr.py"
+	ExecutionScriptName        = "run_trex_daemon"
 )
 
 type Config struct {

--- a/pkg/internal/checkup/trex/configfiles_test.go
+++ b/pkg/internal/checkup/trex/configfiles_test.go
@@ -131,6 +131,21 @@ func TestExecutionScript(t *testing.T) {
 	assert.Equal(t, expextedExecutionScript, actualExecutionScript)
 }
 
+func TestSystemdUnitFile(t *testing.T) {
+	actualSystemdUnitFile := trex.GenerateSystemdUnitFile()
+
+	expectedSystemdUnitFile := `[Unit]
+Description=TRex Server
+[Service]
+WorkingDirectory=/opt/trex
+ExecStart=/opt/trex/run_trex_daemon
+Restart=no
+User=root
+Group=root
+`
+	assert.Equal(t, expectedSystemdUnitFile, actualSystemdUnitFile)
+}
+
 func createSampleConfigs() trex.Config {
 	trafficGeneratorEastMacAddress, _ := net.ParseMAC("00:00:00:00:00:00")
 	trafficGeneratorWestMacAddress, _ := net.ParseMAC("00:00:00:00:00:01")

--- a/pkg/internal/checkup/trex/configfiles_test.go
+++ b/pkg/internal/checkup/trex/configfiles_test.go
@@ -119,6 +119,18 @@ ip_telco1 = '10.1.1.1'
 	assert.Equal(t, expectedAddrPyFile, addrPyFile)
 }
 
+func TestExecutionScript(t *testing.T) {
+	trexConfig := createSampleConfigs()
+
+	actualExecutionScript := trexConfig.GenerateExecutionScript()
+
+	expextedExecutionScript := `#!/usr/bin/env bash
+./t-rex-64 --no-ofed-check --no-scapy-server --no-hw-flow-stat -i -c 6 --iom 0
+`
+
+	assert.Equal(t, expextedExecutionScript, actualExecutionScript)
+}
+
 func createSampleConfigs() trex.Config {
 	trafficGeneratorEastMacAddress, _ := net.ParseMAC("00:00:00:00:00:00")
 	trafficGeneratorWestMacAddress, _ := net.ParseMAC("00:00:00:00:00:01")

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -148,6 +148,7 @@ func trafficGenBootCommands(configDiskSerial string) []string {
 	return []string{
 		fmt.Sprintf("sudo mkdir %s", configMountDirectory),
 		fmt.Sprintf("sudo mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') %s", configDiskSerial, configMountDirectory),
+		fmt.Sprintf("sudo cp %s/%s  /etc/systemd/system", configMountDirectory, trex.SystemdUnitFileName),
 		fmt.Sprintf("sudo cp %s/%s %s", configMountDirectory, trex.ExecutionScriptName, trex.BinDirectory),
 		fmt.Sprintf("sudo chmod 744 %s/%s", trex.BinDirectory, trex.ExecutionScriptName),
 		fmt.Sprintf("sudo cp %s/%s /etc", configMountDirectory, trex.CfgFileName),

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -148,6 +148,8 @@ func trafficGenBootCommands(configDiskSerial string) []string {
 	return []string{
 		fmt.Sprintf("sudo mkdir %s", configMountDirectory),
 		fmt.Sprintf("sudo mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') %s", configDiskSerial, configMountDirectory),
+		fmt.Sprintf("sudo cp %s/%s %s", configMountDirectory, trex.ExecutionScriptName, trex.BinDirectory),
+		fmt.Sprintf("sudo chmod 744 %s/%s", trex.BinDirectory, trex.ExecutionScriptName),
 		fmt.Sprintf("sudo cp %s/%s /etc", configMountDirectory, trex.CfgFileName),
 		fmt.Sprintf("sudo mkdir -p %s", testScriptsDirectory),
 		fmt.Sprintf("sudo cp %s/*.py %s", configMountDirectory, testScriptsDirectory),


### PR DESCRIPTION
The `t-rex-64` application uses the console for input/output.
We wish to use the console to operate TRex as a client, so we need the traffic-gen's serial console to be free.

Add a systemd unit file so executor could start TRex daemon using the following command:
```bash
systemctl start trex
```

A follow-up PR will actually start TRex from the executor.