### PR TITLE
[traffic-gen-in-vm] Run traffic towards the VMI under test

### DIFF
--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -109,6 +109,12 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 		return status.Results{}, err
 	}
 
+	log.Printf("Clearing Trex console stats before test...")
+	if _, err := trexClient.ClearStats(trafficGenVMIName); err != nil {
+		return status.Results{}, fmt.Errorf("failed to clear trex stats on traffic generator VMI \"%s/%s\" side: %w",
+			e.namespace, trafficGenVMIName, err)
+	}
+
 	results := status.Results{}
 	var trafficGeneratorSrcPortStats trex.PortStats
 	var trafficGeneratorDstPortStats trex.PortStats

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -110,6 +110,13 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 			e.namespace, trafficGenVMIName, err)
 	}
 
+	log.Printf("Running traffic for %s...", e.testDuration.String())
+	if _, err := trexClient.StartTraffic(trafficGenVMIName, trex.SourcePort); err != nil {
+		return status.Results{}, fmt.Errorf("failed to run traffic from traffic generator VMI \"%s/%s\" side: %w",
+			e.namespace, trafficGenVMIName, err)
+	}
+	time.Sleep(e.testDuration)
+
 	results := status.Results{}
 	var trafficGeneratorSrcPortStats trex.PortStats
 	var trafficGeneratorDstPortStats trex.PortStats

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -89,7 +89,7 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 		return status.Results{}, fmt.Errorf("failed to Start to Trex Service on VMI \"%s/%s\": %w", e.namespace, trafficGenVMIName, err)
 	}
 
-	trexClient := trex.NewClient(e.vmiSerialClient, e.namespace, e.verbosePrintsEnabled)
+	trexClient := trex.NewClient(e.vmiSerialClient, e.namespace, e.trafficGeneratorPacketsPerSecond, e.testDuration, e.verbosePrintsEnabled)
 
 	log.Printf("Waiting until traffic generator Server Service is ready...")
 	if err := trexClient.WaitForServerToBeReady(ctx, trafficGenVMIName); err != nil {

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -79,11 +79,6 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, trafficGenVMIName, err)
 	}
 
-	const (
-		trafficSourcePort = 0
-		trafficDestPort   = 1
-	)
-
 	log.Printf("Starting traffic generator Server Service...")
 	if err := trex.StartTrexService(e.vmiSerialClient, e.namespace, trafficGenVMIName); err != nil {
 		return status.Results{}, fmt.Errorf("failed to Start to Trex Service on VMI \"%s/%s\": %w", e.namespace, trafficGenVMIName, err)
@@ -120,11 +115,11 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 	var trafficGeneratorDstPortStats trex.PortStats
 
 	results.TrafficGeneratorOutErrorPackets = trafficGeneratorSrcPortStats.Result.Oerrors
-	log.Printf("traffic Generator port %d Packet output errors: %d", trafficSourcePort, results.TrafficGeneratorOutErrorPackets)
+	log.Printf("traffic Generator port %d Packet output errors: %d", trex.SourcePort, results.TrafficGeneratorOutErrorPackets)
 	results.TrafficGeneratorInErrorPackets = trafficGeneratorDstPortStats.Result.Ierrors
-	log.Printf("traffic Generator port %d Packet output errors: %d", trafficDestPort, results.TrafficGeneratorInErrorPackets)
+	log.Printf("traffic Generator port %d Packet output errors: %d", trex.DestPort, results.TrafficGeneratorInErrorPackets)
 	results.TrafficGeneratorTxPackets = trafficGeneratorSrcPortStats.Result.Opackets
-	log.Printf("traffic Generator packet sent via port %d: %d", trafficSourcePort, results.TrafficGeneratorTxPackets)
+	log.Printf("traffic Generator packet sent via port %d: %d", trex.SourcePort, results.TrafficGeneratorTxPackets)
 
 	log.Printf("get testpmd stats in DPDK VMI...")
 	var testPmdStats [testpmd.StatsArraySize]testpmd.PortStats

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -130,7 +130,7 @@ func (t Client) getTrexServiceJournalctl(vmiName string) (string, error) {
 }
 
 func (t Client) runTrexConsoleCmd(vmiName, command string) (string, error) {
-	shellCommand := fmt.Sprintf("/bin/sh -c \"cd /opt/trex && echo %q | ./trex-console -q\"", command)
+	shellCommand := fmt.Sprintf("cd %s && echo %q | ./trex-console -q", BinDirectory, command)
 	resp, err := console.SafeExpectBatchWithResponse(t.vmiSerialClient, t.namespace, vmiName,
 		[]expect.Batcher{
 			&expect.BSnd{S: shellCommand + "\n"},

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -35,20 +35,27 @@ import (
 )
 
 type Client struct {
-	vmiSerialClient      vmiSerialConsoleClient
-	namespace            string
-	verbosePrintsEnabled bool
+	vmiSerialClient                  vmiSerialConsoleClient
+	namespace                        string
+	trafficGeneratorPacketsPerSecond string
+	testDuration                     time.Duration
+	verbosePrintsEnabled             bool
 }
 
 const (
 	StreamsPyPath = "/opt/tests"
 )
 
-func NewClient(vmiSerialClient vmiSerialConsoleClient, namespace string, verbosePrintsEnabled bool) Client {
+func NewClient(vmiSerialClient vmiSerialConsoleClient,
+	namespace, trafficGeneratorPacketsPerSecond string,
+	testDuration time.Duration,
+	verbosePrintsEnabled bool) Client {
 	return Client{
-		vmiSerialClient:      vmiSerialClient,
-		namespace:            namespace,
-		verbosePrintsEnabled: verbosePrintsEnabled,
+		vmiSerialClient:                  vmiSerialClient,
+		namespace:                        namespace,
+		trafficGeneratorPacketsPerSecond: trafficGeneratorPacketsPerSecond,
+		testDuration:                     testDuration,
+		verbosePrintsEnabled:             verbosePrintsEnabled,
 	}
 }
 

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -40,6 +40,10 @@ type Client struct {
 	verbosePrintsEnabled bool
 }
 
+const (
+	StreamsPyPath = "/opt/tests"
+)
+
 func NewClient(vmiSerialClient vmiSerialConsoleClient, namespace string, verbosePrintsEnabled bool) Client {
 	return Client{
 		vmiSerialClient:      vmiSerialClient,

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -151,6 +151,21 @@ func (t Client) ClearStats(vmiName string) (string, error) {
 	return t.runTrexConsoleCmd(vmiName, "clear")
 }
 
+func (t Client) StartTraffic(vmiName string, port PortIdx) (string, error) {
+	startTrafficCmd := t.getStartTrafficCmd(port)
+	return t.runTrexConsoleCmd(vmiName, startTrafficCmd)
+}
+
+func (t Client) getStartTrafficCmd(port PortIdx) string {
+	sb := strings.Builder{}
+	sb.WriteString("start ")
+	sb.WriteString(fmt.Sprintf("-f %s/testpmd.py ", StreamsPyPath))
+	sb.WriteString(fmt.Sprintf("-m %spps ", t.trafficGeneratorPacketsPerSecond))
+	sb.WriteString(fmt.Sprintf("-p %d ", port))
+	sb.WriteString(fmt.Sprintf("-d %.0f", t.testDuration.Seconds()))
+	return sb.String()
+}
+
 func (t Client) runTrexConsoleCmd(vmiName, command string) (string, error) {
 	shellCommand := fmt.Sprintf("cd %s && echo %q | ./trex-console -q", BinDirectory, command)
 	resp, err := console.SafeExpectBatchWithResponse(t.vmiSerialClient, t.namespace, vmiName,

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -42,6 +42,13 @@ type Client struct {
 	verbosePrintsEnabled             bool
 }
 
+type PortIdx int
+
+const (
+	SourcePort PortIdx = iota
+	DestPort
+)
+
 const (
 	StreamsPyPath = "/opt/tests"
 )

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -129,6 +129,10 @@ func (t Client) getTrexServiceJournalctl(vmiName string) (string, error) {
 	return resp[0].Output, err
 }
 
+func (t Client) ClearStats(vmiName string) (string, error) {
+	return t.runTrexConsoleCmd(vmiName, "clear")
+}
+
 func (t Client) runTrexConsoleCmd(vmiName, command string) (string, error) {
 	shellCommand := fmt.Sprintf("cd %s && echo %q | ./trex-console -q", BinDirectory, command)
 	resp, err := console.SafeExpectBatchWithResponse(t.vmiSerialClient, t.namespace, vmiName,

--- a/pkg/internal/checkup/trex/types.go
+++ b/pkg/internal/checkup/trex/types.go
@@ -41,10 +41,10 @@ type GlobalStatsResult struct {
 	MSocketUtil             float64 `json:"m_socket_util"`
 	MTotalAllocError        int64   `json:"m_total_alloc_error"`
 	MTotalClients           int64   `json:"m_total_clients"`
-	MTotalNatActive         int64   `json:"m_total_nat_active "`
+	MTotalNatActive         int64   `json:"m_total_nat_active"`
 	MTotalNatLearnError     int64   `json:"m_total_nat_learn_error"`
 	MTotalNatNoFid          int64   `json:"m_total_nat_no_fid "`
-	MTotalNatOpen           int64   `json:"m_total_nat_open   "`
+	MTotalNatOpen           int64   `json:"m_total_nat_open"`
 	MTotalNatSynWait        int64   `json:"m_total_nat_syn_wait"`
 	MTotalNatTimeOut        int64   `json:"m_total_nat_time_out"`
 	MTotalNatTimeOutWaitAck int64   `json:"m_total_nat_time_out_wait_ack"`

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -144,7 +144,6 @@ func CloudInit(username, password string, bootCommands []string) string {
 
 func trafficGenBootCommands(configDiskSerial string) []string {
 	const configMountDirectory = "/mnt/app-config"
-	const testScriptsDirectory = "/opt/tests"
 
 	return []string{
 		fmt.Sprintf("mkdir %s", configMountDirectory),
@@ -153,7 +152,7 @@ func trafficGenBootCommands(configDiskSerial string) []string {
 		fmt.Sprintf("cp %s %s", path.Join(configMountDirectory, trex.ExecutionScriptName), trex.BinDirectory),
 		fmt.Sprintf("chmod 744 %s", path.Join(trex.BinDirectory, trex.ExecutionScriptName)),
 		fmt.Sprintf("cp %s /etc", path.Join(configMountDirectory, trex.CfgFileName)),
-		fmt.Sprintf("mkdir -p %s", testScriptsDirectory),
-		fmt.Sprintf("cp %s/*.py %s", configMountDirectory, testScriptsDirectory),
+		fmt.Sprintf("mkdir -p %s", trex.StreamsPyPath),
+		fmt.Sprintf("cp %s/*.py %s", configMountDirectory, trex.StreamsPyPath),
 	}
 }


### PR DESCRIPTION
This PR is adding the command that will initiate the DPDK traffic towards the VMI under test, and in the meanwhile will poll the traffic for drop rates on the traffic-generator side.