### PR TITLE
[traffic-gen-in-vm] traffic-gen, boot commands: Remove sudo

### DIFF
--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -146,13 +146,13 @@ func trafficGenBootCommands(configDiskSerial string) []string {
 	const testScriptsDirectory = "/opt/tests"
 
 	return []string{
-		fmt.Sprintf("sudo mkdir %s", configMountDirectory),
-		fmt.Sprintf("sudo mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') %s", configDiskSerial, configMountDirectory),
-		fmt.Sprintf("sudo cp %s/%s  /etc/systemd/system", configMountDirectory, trex.SystemdUnitFileName),
-		fmt.Sprintf("sudo cp %s/%s %s", configMountDirectory, trex.ExecutionScriptName, trex.BinDirectory),
-		fmt.Sprintf("sudo chmod 744 %s/%s", trex.BinDirectory, trex.ExecutionScriptName),
-		fmt.Sprintf("sudo cp %s/%s /etc", configMountDirectory, trex.CfgFileName),
-		fmt.Sprintf("sudo mkdir -p %s", testScriptsDirectory),
-		fmt.Sprintf("sudo cp %s/*.py %s", configMountDirectory, testScriptsDirectory),
+		fmt.Sprintf("mkdir %s", configMountDirectory),
+		fmt.Sprintf("mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') %s", configDiskSerial, configMountDirectory),
+		fmt.Sprintf("cp %s/%s  /etc/systemd/system", configMountDirectory, trex.SystemdUnitFileName),
+		fmt.Sprintf("cp %s/%s %s", configMountDirectory, trex.ExecutionScriptName, trex.BinDirectory),
+		fmt.Sprintf("chmod 744 %s/%s", trex.BinDirectory, trex.ExecutionScriptName),
+		fmt.Sprintf("cp %s/%s /etc", configMountDirectory, trex.CfgFileName),
+		fmt.Sprintf("mkdir -p %s", testScriptsDirectory),
+		fmt.Sprintf("cp %s/*.py %s", configMountDirectory, testScriptsDirectory),
 	}
 }


### PR DESCRIPTION
Currently, all the boot commands have a `sudo` prefix. This was done because we followed an example in the KubeVirt user guide [1].

Apparently, this is not needed, and considerably slows down the boot process of the traffic-gen VMI.

[1] http://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#as-a-disk