### PR TITLE
[traffic-gen-in-vm] Retrieve port stats from Traffic gen

### DIFF
--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -125,6 +125,10 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 	}
 	log.Printf("traffic Generator Max Drop Rate: %fBps", trafficGeneratorMaxDropRate)
 
+	return calculateStats(testpmdConsole, vmiUnderTestName)
+}
+
+func calculateStats(testpmdConsole *testpmd.TestpmdConsole, vmiUnderTestName string) (status.Results, error) {
 	results := status.Results{}
 	var trafficGeneratorSrcPortStats trex.PortStats
 	var trafficGeneratorDstPortStats trex.PortStats
@@ -138,6 +142,7 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 
 	log.Printf("get testpmd stats in DPDK VMI...")
 	var testPmdStats [testpmd.StatsArraySize]testpmd.PortStats
+	var err error
 	if testPmdStats, err = testpmdConsole.GetStats(vmiUnderTestName); err != nil {
 		return status.Results{}, err
 	}

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -190,6 +190,27 @@ func (t Client) GetGlobalStats(vmiName string) (GlobalStats, error) {
 	return gs, nil
 }
 
+func (t Client) GetPortStats(vmiName string, port PortIdx) (PortStats, error) {
+	const (
+		portStatsRequestKey = "get_port_stats"
+	)
+	portStatsJSONString, err := t.runTrexConsoleCmdWithJSONResponse(vmiName, fmt.Sprintf("stats --port %d -p", port), portStatsRequestKey)
+	if err != nil {
+		return PortStats{}, fmt.Errorf("failed to get global stats json: %w", err)
+	}
+
+	if t.verbosePrintsEnabled {
+		log.Printf("GetPortStats JSON: %s", portStatsJSONString)
+	}
+
+	var ps PortStats
+	err = json.Unmarshal([]byte(portStatsJSONString), &ps)
+	if err != nil {
+		return PortStats{}, fmt.Errorf("failed to unmarshal port %d stats json: %w", port, err)
+	}
+	return ps, nil
+}
+
 func (t Client) runTrexConsoleCmd(vmiName, command string) (string, error) {
 	shellCommand := fmt.Sprintf("cd %s && echo %q | ./trex-console -q", BinDirectory, command)
 	resp, err := console.SafeExpectBatchWithResponse(t.vmiSerialClient, t.namespace, vmiName,


### PR DESCRIPTION
This PR is retrieving the traffic gen port stats after the test has run, effectively making the checkup operational again.