### PR TITLE
e2e: Change test trafficGeneratorPacketsPerSecond param

### DIFF
--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -289,11 +289,12 @@ func newConfigMap() *corev1.ConfigMap {
 		},
 		Data: map[string]string{
 			"spec.timeout": "10m",
-			"spec.param.networkAttachmentDefinitionName": networkAttachmentDefinitionName,
-			"spec.param.trafficGeneratorImage":           trafficGeneratorImage,
-			"spec.param.vmContainerDiskImage":            vmContainerDiskImage,
-			"spec.param.testDuration":                    "1m",
-			"spec.param.verbose":                         "true",
+			"spec.param.networkAttachmentDefinitionName":  networkAttachmentDefinitionName,
+			"spec.param.trafficGeneratorImage":            trafficGeneratorImage,
+			"spec.param.trafficGeneratorPacketsPerSecond": "8m",
+			"spec.param.vmContainerDiskImage":             vmContainerDiskImage,
+			"spec.param.testDuration":                     "1m",
+			"spec.param.verbose":                          "true",
 		},
 	}
 }


### PR DESCRIPTION
Since the current CI develipment is a single node cluster (SNO), the traffic that can pass the checkup without maximazing the PF limit is 8 million packats per seconds.