### PR TITLE
GitHub Actions: Remove traffic-gen-in-vm branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - 'release-**'
-      - traffic-gen-in-vm
   pull_request:
     branches:
       - main
       - 'release-**'
-      - traffic-gen-in-vm
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - traffic-gen-in-vm
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/traffic_gen_containerdisk.yaml
+++ b/.github/workflows/traffic_gen_containerdisk.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - 'release-**'
-      - traffic-gen-in-vm
     paths:
       - 'vms/image-builder/**'
       - 'vms/traffic-gen/**'

--- a/.github/workflows/traffic_gen_containerdisk_publish.yaml
+++ b/.github/workflows/traffic_gen_containerdisk_publish.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - traffic-gen-in-vm
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/vm_containerdisk.yaml
+++ b/.github/workflows/vm_containerdisk.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - 'release-**'
-      - traffic-gen-in-vm
     paths:
       - 'vms/image-builder/**'
       - 'vms/vm-under-test/**'

--- a/.github/workflows/vm_containerdisk_publish.yaml
+++ b/.github/workflows/vm_containerdisk_publish.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - traffic-gen-in-vm
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
Following PR #163, the `traffic-gen-in-vm` branch was merged to `main`.
Remove it from the CI.