### PR TITLE
Refactor config

### DIFF
--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -39,9 +39,9 @@ const (
 	TrafficGeneratorWestMacAddressParamName    = "trafficGeneratorWestMacAddress"
 	VMContainerDiskImageParamName              = "vmContainerDiskImage"
 	DPDKNodeLabelSelectorParamName             = "DPDKNodeLabelSelector"
-	PortBandwidthGBParamName                   = "portBandwidthGB"
 	DPDKEastMacAddressParamName                = "DPDKEastMacAddress"
 	DPDKWestMacAddressParamName                = "DPDKWestMacAddress"
+	PortBandwidthGBParamName                   = "portBandwidthGB"
 	TestDurationParamName                      = "testDuration"
 	VerboseParamName                           = "verbose"
 )
@@ -75,9 +75,9 @@ var (
 	ErrInvalidTrafficGeneratorPacketsPerSecond = errors.New("invalid Traffic Generator Packets Per Second")
 	ErrInvalidTrafficGeneratorEastMacAddress   = errors.New("invalid Traffic Generator East MAC Address")
 	ErrInvalidTrafficGeneratorWestMacAddress   = errors.New("invalid Traffic Generator West MAC Address")
-	ErrInvalidPortBandwidthGB                  = errors.New("invalid Port Bandwidth [GB]")
 	ErrInvalidDPDKEastMacAddress               = errors.New("invalid DPDK East MAC Address")
 	ErrInvalidDPDKWestMacAddress               = errors.New("invalid DPDK West MAC Address")
+	ErrInvalidPortBandwidthGB                  = errors.New("invalid Port Bandwidth [GB]")
 	ErrInvalidTestDuration                     = errors.New("invalid Test Duration")
 	ErrInvalidVerbose                          = errors.New("invalid Verbose value [true|false]")
 )
@@ -93,9 +93,9 @@ type Config struct {
 	TrafficGeneratorWestMacAddress    net.HardwareAddr
 	VMContainerDiskImage              string
 	DPDKNodeLabelSelector             string
-	PortBandwidthGB                   int
 	DPDKEastMacAddress                net.HardwareAddr
 	DPDKWestMacAddress                net.HardwareAddr
+	PortBandwidthGB                   int
 	TestDuration                      time.Duration
 	Verbose                           bool
 }
@@ -118,9 +118,9 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		TrafficGeneratorWestMacAddress:    trafficGeneratorWestMacAddressDefault,
 		VMContainerDiskImage:              VMContainerDiskImageDefault,
 		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
-		PortBandwidthGB:                   PortBandwidthGBDefault,
 		DPDKEastMacAddress:                dpdkEastMacAddressDefault,
 		DPDKWestMacAddress:                dpdkWestMacAddressDefault,
+		PortBandwidthGB:                   PortBandwidthGBDefault,
 		TestDuration:                      TestDurationDefault,
 		Verbose:                           VerboseDefault,
 	}

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -162,17 +162,17 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 		}
 	}
 
-	if rawVal := baseConfig.Params[VerboseParamName]; rawVal != "" {
-		newConfig.Verbose, err = strconv.ParseBool(rawVal)
-		if err != nil {
-			return Config{}, ErrInvalidVerbose
-		}
-	}
-
 	if rawVal := baseConfig.Params[PortBandwidthGBParamName]; rawVal != "" {
 		newConfig.PortBandwidthGB, err = parseNonZeroPositiveInt(rawVal)
 		if err != nil {
 			return Config{}, ErrInvalidPortBandwidthGB
+		}
+	}
+
+	if rawVal := baseConfig.Params[VerboseParamName]; rawVal != "" {
+		newConfig.Verbose, err = strconv.ParseBool(rawVal)
+		if err != nil {
+			return Config{}, ErrInvalidVerbose
 		}
 	}
 

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -35,10 +35,10 @@ const (
 	TrafficGeneratorImageParamName             = "trafficGeneratorImage"
 	TrafficGeneratorNodeLabelSelectorParamName = "trafficGeneratorNodeLabelSelector"
 	TrafficGeneratorPacketsPerSecondParamName  = "trafficGeneratorPacketsPerSecond"
-	DPDKNodeLabelSelectorParamName             = "DPDKNodeLabelSelector"
-	PortBandwidthGBParamName                   = "portBandwidthGB"
 	TrafficGeneratorEastMacAddressParamName    = "trafficGeneratorEastMacAddress"
 	TrafficGeneratorWestMacAddressParamName    = "trafficGeneratorWestMacAddress"
+	DPDKNodeLabelSelectorParamName             = "DPDKNodeLabelSelector"
+	PortBandwidthGBParamName                   = "portBandwidthGB"
 	DPDKEastMacAddressParamName                = "DPDKEastMacAddress"
 	DPDKWestMacAddressParamName                = "DPDKWestMacAddress"
 	VMContainerDiskImageParamName              = "vmContainerDiskImage"
@@ -73,9 +73,9 @@ var (
 	ErrIllegalLabelSelectorCombination        = errors.New("illegal Traffic Generator and DPDK Node " +
 		"Label Selector combination")
 	ErrInvalidTrafficGeneratorPacketsPerSecond = errors.New("invalid Traffic Generator Packets Per Second")
-	ErrInvalidPortBandwidthGB                  = errors.New("invalid Port Bandwidth [GB]")
 	ErrInvalidTrafficGeneratorEastMacAddress   = errors.New("invalid Traffic Generator East MAC Address")
 	ErrInvalidTrafficGeneratorWestMacAddress   = errors.New("invalid Traffic Generator West MAC Address")
+	ErrInvalidPortBandwidthGB                  = errors.New("invalid Port Bandwidth [GB]")
 	ErrInvalidDPDKEastMacAddress               = errors.New("invalid DPDK East MAC Address")
 	ErrInvalidDPDKWestMacAddress               = errors.New("invalid DPDK West MAC Address")
 	ErrInvalidTestDuration                     = errors.New("invalid Test Duration")
@@ -89,10 +89,10 @@ type Config struct {
 	TrafficGeneratorImage             string
 	TrafficGeneratorNodeLabelSelector string
 	TrafficGeneratorPacketsPerSecond  string
-	DPDKNodeLabelSelector             string
-	PortBandwidthGB                   int
 	TrafficGeneratorEastMacAddress    net.HardwareAddr
 	TrafficGeneratorWestMacAddress    net.HardwareAddr
+	DPDKNodeLabelSelector             string
+	PortBandwidthGB                   int
 	DPDKEastMacAddress                net.HardwareAddr
 	DPDKWestMacAddress                net.HardwareAddr
 	VMContainerDiskImage              string
@@ -114,10 +114,10 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		TrafficGeneratorImage:             TrafficGeneratorImageDefault,
 		TrafficGeneratorNodeLabelSelector: baseConfig.Params[TrafficGeneratorNodeLabelSelectorParamName],
 		TrafficGeneratorPacketsPerSecond:  TrafficGeneratorPacketsPerSecondDefault,
-		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
-		PortBandwidthGB:                   PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress:    trafficGeneratorEastMacAddressDefault,
 		TrafficGeneratorWestMacAddress:    trafficGeneratorWestMacAddressDefault,
+		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
+		PortBandwidthGB:                   PortBandwidthGBDefault,
 		DPDKEastMacAddress:                dpdkEastMacAddressDefault,
 		DPDKWestMacAddress:                dpdkWestMacAddressDefault,
 		VMContainerDiskImage:              VMContainerDiskImageDefault,

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -37,11 +37,11 @@ const (
 	TrafficGeneratorPacketsPerSecondParamName  = "trafficGeneratorPacketsPerSecond"
 	TrafficGeneratorEastMacAddressParamName    = "trafficGeneratorEastMacAddress"
 	TrafficGeneratorWestMacAddressParamName    = "trafficGeneratorWestMacAddress"
+	VMContainerDiskImageParamName              = "vmContainerDiskImage"
 	DPDKNodeLabelSelectorParamName             = "DPDKNodeLabelSelector"
 	PortBandwidthGBParamName                   = "portBandwidthGB"
 	DPDKEastMacAddressParamName                = "DPDKEastMacAddress"
 	DPDKWestMacAddressParamName                = "DPDKWestMacAddress"
-	VMContainerDiskImageParamName              = "vmContainerDiskImage"
 	TestDurationParamName                      = "testDuration"
 	VerboseParamName                           = "verbose"
 )
@@ -49,8 +49,8 @@ const (
 const (
 	TrafficGeneratorImageDefault            = "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main"
 	TrafficGeneratorPacketsPerSecondDefault = "14m"
-	PortBandwidthGBDefault                  = 10
 	VMContainerDiskImageDefault             = "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main"
+	PortBandwidthGBDefault                  = 10
 	TestDurationDefault                     = 5 * time.Minute
 	VerboseDefault                          = false
 
@@ -91,11 +91,11 @@ type Config struct {
 	TrafficGeneratorPacketsPerSecond  string
 	TrafficGeneratorEastMacAddress    net.HardwareAddr
 	TrafficGeneratorWestMacAddress    net.HardwareAddr
+	VMContainerDiskImage              string
 	DPDKNodeLabelSelector             string
 	PortBandwidthGB                   int
 	DPDKEastMacAddress                net.HardwareAddr
 	DPDKWestMacAddress                net.HardwareAddr
-	VMContainerDiskImage              string
 	TestDuration                      time.Duration
 	Verbose                           bool
 }
@@ -116,11 +116,11 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		TrafficGeneratorPacketsPerSecond:  TrafficGeneratorPacketsPerSecondDefault,
 		TrafficGeneratorEastMacAddress:    trafficGeneratorEastMacAddressDefault,
 		TrafficGeneratorWestMacAddress:    trafficGeneratorWestMacAddressDefault,
+		VMContainerDiskImage:              VMContainerDiskImageDefault,
 		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
 		PortBandwidthGB:                   PortBandwidthGBDefault,
 		DPDKEastMacAddress:                dpdkEastMacAddressDefault,
 		DPDKWestMacAddress:                dpdkWestMacAddressDefault,
-		VMContainerDiskImage:              VMContainerDiskImageDefault,
 		TestDuration:                      TestDurationDefault,
 		Verbose:                           VerboseDefault,
 	}
@@ -151,6 +151,10 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 		}
 	}
 
+	if rawVal := baseConfig.Params[VMContainerDiskImageParamName]; rawVal != "" {
+		newConfig.VMContainerDiskImage = rawVal
+	}
+
 	if rawVal := baseConfig.Params[VerboseParamName]; rawVal != "" {
 		newConfig.Verbose, err = strconv.ParseBool(rawVal)
 		if err != nil {
@@ -168,10 +172,6 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 	newConfig, err = setMacAddressParams(baseConfig, newConfig)
 	if err != nil {
 		return Config{}, err
-	}
-
-	if rawVal := baseConfig.Params[VMContainerDiskImageParamName]; rawVal != "" {
-		newConfig.VMContainerDiskImage = rawVal
 	}
 
 	if rawVal := baseConfig.Params[TestDurationParamName]; rawVal != "" {

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	NetworkAttachmentDefinitionNameParamName   = "networkAttachmentDefinitionName"
+	TrafficGeneratorImageParamName             = "trafficGeneratorImage"
 	TrafficGeneratorNodeLabelSelectorParamName = "trafficGeneratorNodeLabelSelector"
 	DPDKNodeLabelSelectorParamName             = "DPDKNodeLabelSelector"
 	TrafficGeneratorPacketsPerSecondParamName  = "trafficGeneratorPacketsPerSecond"
@@ -40,16 +41,15 @@ const (
 	TrafficGeneratorWestMacAddressParamName    = "trafficGeneratorWestMacAddress"
 	DPDKEastMacAddressParamName                = "DPDKEastMacAddress"
 	DPDKWestMacAddressParamName                = "DPDKWestMacAddress"
-	TrafficGeneratorImageParamName             = "trafficGeneratorImage"
 	VMContainerDiskImageParamName              = "vmContainerDiskImage"
 	TestDurationParamName                      = "testDuration"
 	VerboseParamName                           = "verbose"
 )
 
 const (
+	TrafficGeneratorImageDefault            = "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main"
 	TrafficGeneratorPacketsPerSecondDefault = "14m"
 	PortBandwidthGBDefault                  = 10
-	TrafficGeneratorImageDefault            = "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main"
 	VMContainerDiskImageDefault             = "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main"
 	TestDurationDefault                     = 5 * time.Minute
 	VerboseDefault                          = false
@@ -86,6 +86,7 @@ type Config struct {
 	PodName                           string
 	PodUID                            string
 	NetworkAttachmentDefinitionName   string
+	TrafficGeneratorImage             string
 	TrafficGeneratorNodeLabelSelector string
 	DPDKNodeLabelSelector             string
 	TrafficGeneratorPacketsPerSecond  string
@@ -94,7 +95,6 @@ type Config struct {
 	TrafficGeneratorWestMacAddress    net.HardwareAddr
 	DPDKEastMacAddress                net.HardwareAddr
 	DPDKWestMacAddress                net.HardwareAddr
-	TrafficGeneratorImage             string
 	VMContainerDiskImage              string
 	TestDuration                      time.Duration
 	Verbose                           bool
@@ -111,6 +111,7 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		PodName:                           baseConfig.PodName,
 		PodUID:                            baseConfig.PodUID,
 		NetworkAttachmentDefinitionName:   baseConfig.Params[NetworkAttachmentDefinitionNameParamName],
+		TrafficGeneratorImage:             TrafficGeneratorImageDefault,
 		TrafficGeneratorNodeLabelSelector: baseConfig.Params[TrafficGeneratorNodeLabelSelectorParamName],
 		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
 		TrafficGeneratorPacketsPerSecond:  TrafficGeneratorPacketsPerSecondDefault,
@@ -119,7 +120,6 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		TrafficGeneratorWestMacAddress:    trafficGeneratorWestMacAddressDefault,
 		DPDKEastMacAddress:                dpdkEastMacAddressDefault,
 		DPDKWestMacAddress:                dpdkWestMacAddressDefault,
-		TrafficGeneratorImage:             TrafficGeneratorImageDefault,
 		VMContainerDiskImage:              VMContainerDiskImageDefault,
 		TestDuration:                      TestDurationDefault,
 		Verbose:                           VerboseDefault,
@@ -139,6 +139,10 @@ func New(baseConfig kconfig.Config) (Config, error) {
 
 func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, error) {
 	var err error
+
+	if rawVal := baseConfig.Params[TrafficGeneratorImageParamName]; rawVal != "" {
+		newConfig.TrafficGeneratorImage = rawVal
+	}
 
 	if rawVal := baseConfig.Params[VerboseParamName]; rawVal != "" {
 		newConfig.Verbose, err = strconv.ParseBool(rawVal)
@@ -164,10 +168,6 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 	newConfig, err = setMacAddressParams(baseConfig, newConfig)
 	if err != nil {
 		return Config{}, err
-	}
-
-	if rawVal := baseConfig.Params[TrafficGeneratorImageParamName]; rawVal != "" {
-		newConfig.TrafficGeneratorImage = rawVal
 	}
 
 	if rawVal := baseConfig.Params[VMContainerDiskImageParamName]; rawVal != "" {

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -34,8 +34,8 @@ const (
 	NetworkAttachmentDefinitionNameParamName   = "networkAttachmentDefinitionName"
 	TrafficGeneratorImageParamName             = "trafficGeneratorImage"
 	TrafficGeneratorNodeLabelSelectorParamName = "trafficGeneratorNodeLabelSelector"
-	DPDKNodeLabelSelectorParamName             = "DPDKNodeLabelSelector"
 	TrafficGeneratorPacketsPerSecondParamName  = "trafficGeneratorPacketsPerSecond"
+	DPDKNodeLabelSelectorParamName             = "DPDKNodeLabelSelector"
 	PortBandwidthGBParamName                   = "portBandwidthGB"
 	TrafficGeneratorEastMacAddressParamName    = "trafficGeneratorEastMacAddress"
 	TrafficGeneratorWestMacAddressParamName    = "trafficGeneratorWestMacAddress"
@@ -88,8 +88,8 @@ type Config struct {
 	NetworkAttachmentDefinitionName   string
 	TrafficGeneratorImage             string
 	TrafficGeneratorNodeLabelSelector string
-	DPDKNodeLabelSelector             string
 	TrafficGeneratorPacketsPerSecond  string
+	DPDKNodeLabelSelector             string
 	PortBandwidthGB                   int
 	TrafficGeneratorEastMacAddress    net.HardwareAddr
 	TrafficGeneratorWestMacAddress    net.HardwareAddr
@@ -113,8 +113,8 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		NetworkAttachmentDefinitionName:   baseConfig.Params[NetworkAttachmentDefinitionNameParamName],
 		TrafficGeneratorImage:             TrafficGeneratorImageDefault,
 		TrafficGeneratorNodeLabelSelector: baseConfig.Params[TrafficGeneratorNodeLabelSelectorParamName],
-		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
 		TrafficGeneratorPacketsPerSecond:  TrafficGeneratorPacketsPerSecondDefault,
+		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
 		PortBandwidthGB:                   PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress:    trafficGeneratorEastMacAddressDefault,
 		TrafficGeneratorWestMacAddress:    trafficGeneratorWestMacAddressDefault,
@@ -144,17 +144,17 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 		newConfig.TrafficGeneratorImage = rawVal
 	}
 
-	if rawVal := baseConfig.Params[VerboseParamName]; rawVal != "" {
-		newConfig.Verbose, err = strconv.ParseBool(rawVal)
-		if err != nil {
-			return Config{}, ErrInvalidVerbose
-		}
-	}
-
 	if rawVal := baseConfig.Params[TrafficGeneratorPacketsPerSecondParamName]; rawVal != "" {
 		newConfig.TrafficGeneratorPacketsPerSecond, err = parseTrafficGeneratorPacketsPerSecond(rawVal)
 		if err != nil {
 			return Config{}, ErrInvalidTrafficGeneratorPacketsPerSecond
+		}
+	}
+
+	if rawVal := baseConfig.Params[VerboseParamName]; rawVal != "" {
+		newConfig.Verbose, err = strconv.ParseBool(rawVal)
+		if err != nil {
+			return Config{}, ErrInvalidVerbose
 		}
 	}
 

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -41,8 +41,8 @@ const (
 	DPDKNodeLabelSelectorParamName             = "DPDKNodeLabelSelector"
 	DPDKEastMacAddressParamName                = "DPDKEastMacAddress"
 	DPDKWestMacAddressParamName                = "DPDKWestMacAddress"
-	PortBandwidthGBParamName                   = "portBandwidthGB"
 	TestDurationParamName                      = "testDuration"
+	PortBandwidthGBParamName                   = "portBandwidthGB"
 	VerboseParamName                           = "verbose"
 )
 
@@ -50,8 +50,8 @@ const (
 	TrafficGeneratorImageDefault            = "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main"
 	TrafficGeneratorPacketsPerSecondDefault = "14m"
 	VMContainerDiskImageDefault             = "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main"
-	PortBandwidthGBDefault                  = 10
 	TestDurationDefault                     = 5 * time.Minute
+	PortBandwidthGBDefault                  = 10
 	VerboseDefault                          = false
 
 	TrafficGeneratorMacAddressPrefixOctet = 0x50
@@ -77,8 +77,8 @@ var (
 	ErrInvalidTrafficGeneratorWestMacAddress   = errors.New("invalid Traffic Generator West MAC Address")
 	ErrInvalidDPDKEastMacAddress               = errors.New("invalid DPDK East MAC Address")
 	ErrInvalidDPDKWestMacAddress               = errors.New("invalid DPDK West MAC Address")
-	ErrInvalidPortBandwidthGB                  = errors.New("invalid Port Bandwidth [GB]")
 	ErrInvalidTestDuration                     = errors.New("invalid Test Duration")
+	ErrInvalidPortBandwidthGB                  = errors.New("invalid Port Bandwidth [GB]")
 	ErrInvalidVerbose                          = errors.New("invalid Verbose value [true|false]")
 )
 
@@ -95,8 +95,8 @@ type Config struct {
 	DPDKNodeLabelSelector             string
 	DPDKEastMacAddress                net.HardwareAddr
 	DPDKWestMacAddress                net.HardwareAddr
-	PortBandwidthGB                   int
 	TestDuration                      time.Duration
+	PortBandwidthGB                   int
 	Verbose                           bool
 }
 
@@ -120,8 +120,8 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		DPDKNodeLabelSelector:             baseConfig.Params[DPDKNodeLabelSelectorParamName],
 		DPDKEastMacAddress:                dpdkEastMacAddressDefault,
 		DPDKWestMacAddress:                dpdkWestMacAddressDefault,
-		PortBandwidthGB:                   PortBandwidthGBDefault,
 		TestDuration:                      TestDurationDefault,
+		PortBandwidthGB:                   PortBandwidthGBDefault,
 		Verbose:                           VerboseDefault,
 	}
 
@@ -155,6 +155,13 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 		newConfig.VMContainerDiskImage = rawVal
 	}
 
+	if rawVal := baseConfig.Params[TestDurationParamName]; rawVal != "" {
+		newConfig.TestDuration, err = time.ParseDuration(rawVal)
+		if err != nil {
+			return Config{}, ErrInvalidTestDuration
+		}
+	}
+
 	if rawVal := baseConfig.Params[VerboseParamName]; rawVal != "" {
 		newConfig.Verbose, err = strconv.ParseBool(rawVal)
 		if err != nil {
@@ -172,13 +179,6 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 	newConfig, err = setMacAddressParams(baseConfig, newConfig)
 	if err != nil {
 		return Config{}, err
-	}
-
-	if rawVal := baseConfig.Params[TestDurationParamName]; rawVal != "" {
-		newConfig.TestDuration, err = time.ParseDuration(rawVal)
-		if err != nil {
-			return Config{}, ErrInvalidTestDuration
-		}
 	}
 
 	return newConfig, nil

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -42,11 +42,11 @@ const (
 	trafficGeneratorPacketsPerSecond  = "6m"
 	trafficGeneratorEastMacAddress    = "DE:AD:BE:EF:00:01"
 	trafficGeneratorWestMacAddress    = "DE:AD:BE:EF:01:00"
+	vmContainerDiskImage              = "quay.io/ramlavi/kubevirt-dpdk-checkup-vm:main"
 	portBandwidthGB                   = 100
 	dpdkNodeLabelSelector             = "node-role.kubernetes.io/worker-dpdk2"
 	dpdkEastMacAddress                = "DE:AD:BE:EF:00:02"
 	dpdkWestMacAddress                = "DE:AD:BE:EF:02:00"
-	vmContainerDiskImage              = "quay.io/ramlavi/kubevirt-dpdk-checkup-vm:main"
 	testDuration                      = "30m"
 )
 
@@ -75,10 +75,10 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		TrafficGeneratorPacketsPerSecond: config.TrafficGeneratorPacketsPerSecondDefault,
 		TrafficGeneratorEastMacAddress:   actualConfig.TrafficGeneratorEastMacAddress,
 		TrafficGeneratorWestMacAddress:   actualConfig.TrafficGeneratorWestMacAddress,
+		VMContainerDiskImage:             config.VMContainerDiskImageDefault,
 		PortBandwidthGB:                  config.PortBandwidthGBDefault,
 		DPDKEastMacAddress:               actualConfig.DPDKEastMacAddress,
 		DPDKWestMacAddress:               actualConfig.DPDKWestMacAddress,
-		VMContainerDiskImage:             config.VMContainerDiskImageDefault,
 		TestDuration:                     config.TestDurationDefault,
 		Verbose:                          config.VerboseDefault,
 	}
@@ -111,10 +111,10 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				TrafficGeneratorPacketsPerSecond:  trafficGeneratorPacketsPerSecond,
 				TrafficGeneratorEastMacAddress:    trafficGeneratorEastHWAddress,
 				TrafficGeneratorWestMacAddress:    trafficGeneratorWestHWAddress,
+				VMContainerDiskImage:              vmContainerDiskImage,
 				DPDKNodeLabelSelector:             dpdkNodeLabelSelector,
 				DPDKEastMacAddress:                dpdkEastHWAddress,
 				DPDKWestMacAddress:                dpdkWestHWAddress,
-				VMContainerDiskImage:              vmContainerDiskImage,
 				TestDuration:                      30 * time.Minute,
 				Verbose:                           true,
 			},
@@ -131,9 +131,9 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				TrafficGeneratorPacketsPerSecond: trafficGeneratorPacketsPerSecond,
 				TrafficGeneratorEastMacAddress:   trafficGeneratorEastHWAddress,
 				TrafficGeneratorWestMacAddress:   trafficGeneratorWestHWAddress,
+				VMContainerDiskImage:             vmContainerDiskImage,
 				DPDKEastMacAddress:               dpdkEastHWAddress,
 				DPDKWestMacAddress:               dpdkWestHWAddress,
-				VMContainerDiskImage:             vmContainerDiskImage,
 				TestDuration:                     30 * time.Minute,
 				Verbose:                          true,
 			},
@@ -278,11 +278,11 @@ func getValidUserParameters() map[string]string {
 		config.TrafficGeneratorPacketsPerSecondParamName:  trafficGeneratorPacketsPerSecond,
 		config.TrafficGeneratorEastMacAddressParamName:    trafficGeneratorEastMacAddress,
 		config.TrafficGeneratorWestMacAddressParamName:    trafficGeneratorWestMacAddress,
+		config.VMContainerDiskImageParamName:              vmContainerDiskImage,
 		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.DPDKNodeLabelSelectorParamName:             dpdkNodeLabelSelector,
 		config.DPDKEastMacAddressParamName:                dpdkEastMacAddress,
 		config.DPDKWestMacAddressParamName:                dpdkWestMacAddress,
-		config.VMContainerDiskImageParamName:              vmContainerDiskImage,
 		config.TestDurationParamName:                      testDuration,
 		config.VerboseParamName:                           strconv.FormatBool(true),
 	}

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -39,8 +39,8 @@ const (
 	networkAttachmentDefinitionName   = "intel-dpdk-network1"
 	trafficGeneratorImage             = "quay.io/ramlavi/kubevirt-dpdk-checkup-traffic-gen:main"
 	trafficGeneratorNodeLabelSelector = "node-role.kubernetes.io/worker-dpdk1"
-	portBandwidthGB                   = 100
 	trafficGeneratorPacketsPerSecond  = "6m"
+	portBandwidthGB                   = 100
 	dpdkNodeLabelSelector             = "node-role.kubernetes.io/worker-dpdk2"
 	trafficGeneratorEastMacAddress    = "DE:AD:BE:EF:00:01"
 	trafficGeneratorWestMacAddress    = "DE:AD:BE:EF:01:00"
@@ -275,8 +275,8 @@ func getValidUserParameters() map[string]string {
 		config.NetworkAttachmentDefinitionNameParamName:   networkAttachmentDefinitionName,
 		config.TrafficGeneratorImageParamName:             trafficGeneratorImage,
 		config.TrafficGeneratorNodeLabelSelectorParamName: trafficGeneratorNodeLabelSelector,
-		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.TrafficGeneratorPacketsPerSecondParamName:  trafficGeneratorPacketsPerSecond,
+		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.DPDKNodeLabelSelectorParamName:             dpdkNodeLabelSelector,
 		config.TrafficGeneratorEastMacAddressParamName:    trafficGeneratorEastMacAddress,
 		config.TrafficGeneratorWestMacAddressParamName:    trafficGeneratorWestMacAddress,

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -38,8 +38,8 @@ const (
 	testPodUID                        = "0123456789-0123456789"
 	networkAttachmentDefinitionName   = "intel-dpdk-network1"
 	trafficGeneratorImage             = "quay.io/ramlavi/kubevirt-dpdk-checkup-traffic-gen:main"
-	portBandwidthGB                   = 100
 	trafficGeneratorNodeLabelSelector = "node-role.kubernetes.io/worker-dpdk1"
+	portBandwidthGB                   = 100
 	trafficGeneratorPacketsPerSecond  = "6m"
 	dpdkNodeLabelSelector             = "node-role.kubernetes.io/worker-dpdk2"
 	trafficGeneratorEastMacAddress    = "DE:AD:BE:EF:00:01"
@@ -107,8 +107,8 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				PortBandwidthGB:                   portBandwidthGB,
 				NetworkAttachmentDefinitionName:   networkAttachmentDefinitionName,
 				TrafficGeneratorImage:             trafficGeneratorImage,
-				TrafficGeneratorPacketsPerSecond:  trafficGeneratorPacketsPerSecond,
 				TrafficGeneratorNodeLabelSelector: trafficGeneratorNodeLabelSelector,
+				TrafficGeneratorPacketsPerSecond:  trafficGeneratorPacketsPerSecond,
 				DPDKNodeLabelSelector:             dpdkNodeLabelSelector,
 				TrafficGeneratorEastMacAddress:    trafficGeneratorEastHWAddress,
 				TrafficGeneratorWestMacAddress:    trafficGeneratorWestHWAddress,
@@ -274,8 +274,8 @@ func getValidUserParameters() map[string]string {
 	return map[string]string{
 		config.NetworkAttachmentDefinitionNameParamName:   networkAttachmentDefinitionName,
 		config.TrafficGeneratorImageParamName:             trafficGeneratorImage,
-		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.TrafficGeneratorNodeLabelSelectorParamName: trafficGeneratorNodeLabelSelector,
+		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.TrafficGeneratorPacketsPerSecondParamName:  trafficGeneratorPacketsPerSecond,
 		config.DPDKNodeLabelSelectorParamName:             dpdkNodeLabelSelector,
 		config.TrafficGeneratorEastMacAddressParamName:    trafficGeneratorEastMacAddress,

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -44,9 +44,9 @@ const (
 	trafficGeneratorWestMacAddress    = "DE:AD:BE:EF:01:00"
 	vmContainerDiskImage              = "quay.io/ramlavi/kubevirt-dpdk-checkup-vm:main"
 	dpdkNodeLabelSelector             = "node-role.kubernetes.io/worker-dpdk2"
-	portBandwidthGB                   = 100
 	dpdkEastMacAddress                = "DE:AD:BE:EF:00:02"
 	dpdkWestMacAddress                = "DE:AD:BE:EF:02:00"
+	portBandwidthGB                   = 100
 	testDuration                      = "30m"
 )
 
@@ -76,9 +76,9 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		TrafficGeneratorEastMacAddress:   actualConfig.TrafficGeneratorEastMacAddress,
 		TrafficGeneratorWestMacAddress:   actualConfig.TrafficGeneratorWestMacAddress,
 		VMContainerDiskImage:             config.VMContainerDiskImageDefault,
-		PortBandwidthGB:                  config.PortBandwidthGBDefault,
 		DPDKEastMacAddress:               actualConfig.DPDKEastMacAddress,
 		DPDKWestMacAddress:               actualConfig.DPDKWestMacAddress,
+		PortBandwidthGB:                  config.PortBandwidthGBDefault,
 		TestDuration:                     config.TestDurationDefault,
 		Verbose:                          config.VerboseDefault,
 	}
@@ -207,12 +207,6 @@ func TestNewShouldFailWhen(t *testing.T) {
 			expectedError:  config.ErrInvalidTrafficGeneratorWestMacAddress,
 		},
 		{
-			description:    "PortBandwidthGB is invalid",
-			key:            config.PortBandwidthGBParamName,
-			faultyKeyValue: "0",
-			expectedError:  config.ErrInvalidPortBandwidthGB,
-		},
-		{
 			description:    "DPDKEastMacAddress is invalid",
 			key:            config.DPDKEastMacAddressParamName,
 			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
@@ -223,6 +217,12 @@ func TestNewShouldFailWhen(t *testing.T) {
 			key:            config.DPDKWestMacAddressParamName,
 			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
 			expectedError:  config.ErrInvalidDPDKWestMacAddress,
+		},
+		{
+			description:    "PortBandwidthGB is invalid",
+			key:            config.PortBandwidthGBParamName,
+			faultyKeyValue: "0",
+			expectedError:  config.ErrInvalidPortBandwidthGB,
 		},
 		{
 			description:    "TestDuration is invalid",
@@ -280,9 +280,9 @@ func getValidUserParameters() map[string]string {
 		config.TrafficGeneratorWestMacAddressParamName:    trafficGeneratorWestMacAddress,
 		config.VMContainerDiskImageParamName:              vmContainerDiskImage,
 		config.DPDKNodeLabelSelectorParamName:             dpdkNodeLabelSelector,
-		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.DPDKEastMacAddressParamName:                dpdkEastMacAddress,
 		config.DPDKWestMacAddressParamName:                dpdkWestMacAddress,
+		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.TestDurationParamName:                      testDuration,
 		config.VerboseParamName:                           strconv.FormatBool(true),
 	}

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -40,10 +40,10 @@ const (
 	trafficGeneratorImage             = "quay.io/ramlavi/kubevirt-dpdk-checkup-traffic-gen:main"
 	trafficGeneratorNodeLabelSelector = "node-role.kubernetes.io/worker-dpdk1"
 	trafficGeneratorPacketsPerSecond  = "6m"
-	portBandwidthGB                   = 100
-	dpdkNodeLabelSelector             = "node-role.kubernetes.io/worker-dpdk2"
 	trafficGeneratorEastMacAddress    = "DE:AD:BE:EF:00:01"
 	trafficGeneratorWestMacAddress    = "DE:AD:BE:EF:01:00"
+	portBandwidthGB                   = 100
+	dpdkNodeLabelSelector             = "node-role.kubernetes.io/worker-dpdk2"
 	dpdkEastMacAddress                = "DE:AD:BE:EF:00:02"
 	dpdkWestMacAddress                = "DE:AD:BE:EF:02:00"
 	vmContainerDiskImage              = "quay.io/ramlavi/kubevirt-dpdk-checkup-vm:main"
@@ -73,9 +73,9 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		NetworkAttachmentDefinitionName:  networkAttachmentDefinitionName,
 		TrafficGeneratorImage:            config.TrafficGeneratorImageDefault,
 		TrafficGeneratorPacketsPerSecond: config.TrafficGeneratorPacketsPerSecondDefault,
-		PortBandwidthGB:                  config.PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress:   actualConfig.TrafficGeneratorEastMacAddress,
 		TrafficGeneratorWestMacAddress:   actualConfig.TrafficGeneratorWestMacAddress,
+		PortBandwidthGB:                  config.PortBandwidthGBDefault,
 		DPDKEastMacAddress:               actualConfig.DPDKEastMacAddress,
 		DPDKWestMacAddress:               actualConfig.DPDKWestMacAddress,
 		VMContainerDiskImage:             config.VMContainerDiskImageDefault,
@@ -109,9 +109,9 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				TrafficGeneratorImage:             trafficGeneratorImage,
 				TrafficGeneratorNodeLabelSelector: trafficGeneratorNodeLabelSelector,
 				TrafficGeneratorPacketsPerSecond:  trafficGeneratorPacketsPerSecond,
-				DPDKNodeLabelSelector:             dpdkNodeLabelSelector,
 				TrafficGeneratorEastMacAddress:    trafficGeneratorEastHWAddress,
 				TrafficGeneratorWestMacAddress:    trafficGeneratorWestHWAddress,
+				DPDKNodeLabelSelector:             dpdkNodeLabelSelector,
 				DPDKEastMacAddress:                dpdkEastHWAddress,
 				DPDKWestMacAddress:                dpdkWestHWAddress,
 				VMContainerDiskImage:              vmContainerDiskImage,
@@ -195,12 +195,6 @@ func TestNewShouldFailWhen(t *testing.T) {
 			expectedError:  config.ErrInvalidTrafficGeneratorPacketsPerSecond,
 		},
 		{
-			description:    "PortBandwidthGB is invalid",
-			key:            config.PortBandwidthGBParamName,
-			faultyKeyValue: "0",
-			expectedError:  config.ErrInvalidPortBandwidthGB,
-		},
-		{
 			description:    "TrafficGeneratorEastMacAddress is invalid",
 			key:            config.TrafficGeneratorEastMacAddressParamName,
 			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
@@ -211,6 +205,12 @@ func TestNewShouldFailWhen(t *testing.T) {
 			key:            config.TrafficGeneratorWestMacAddressParamName,
 			faultyKeyValue: "AB:CD:EF:GH:IJ:KH",
 			expectedError:  config.ErrInvalidTrafficGeneratorWestMacAddress,
+		},
+		{
+			description:    "PortBandwidthGB is invalid",
+			key:            config.PortBandwidthGBParamName,
+			faultyKeyValue: "0",
+			expectedError:  config.ErrInvalidPortBandwidthGB,
 		},
 		{
 			description:    "DPDKEastMacAddress is invalid",
@@ -276,10 +276,10 @@ func getValidUserParameters() map[string]string {
 		config.TrafficGeneratorImageParamName:             trafficGeneratorImage,
 		config.TrafficGeneratorNodeLabelSelectorParamName: trafficGeneratorNodeLabelSelector,
 		config.TrafficGeneratorPacketsPerSecondParamName:  trafficGeneratorPacketsPerSecond,
-		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
-		config.DPDKNodeLabelSelectorParamName:             dpdkNodeLabelSelector,
 		config.TrafficGeneratorEastMacAddressParamName:    trafficGeneratorEastMacAddress,
 		config.TrafficGeneratorWestMacAddressParamName:    trafficGeneratorWestMacAddress,
+		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
+		config.DPDKNodeLabelSelectorParamName:             dpdkNodeLabelSelector,
 		config.DPDKEastMacAddressParamName:                dpdkEastMacAddress,
 		config.DPDKWestMacAddressParamName:                dpdkWestMacAddress,
 		config.VMContainerDiskImageParamName:              vmContainerDiskImage,

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -104,7 +104,6 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 			config.Config{
 				PodName:                           testPodName,
 				PodUID:                            testPodUID,
-				PortBandwidthGB:                   portBandwidthGB,
 				NetworkAttachmentDefinitionName:   networkAttachmentDefinitionName,
 				TrafficGeneratorImage:             trafficGeneratorImage,
 				TrafficGeneratorNodeLabelSelector: trafficGeneratorNodeLabelSelector,
@@ -116,6 +115,7 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				DPDKEastMacAddress:                dpdkEastHWAddress,
 				DPDKWestMacAddress:                dpdkWestHWAddress,
 				TestDuration:                      30 * time.Minute,
+				PortBandwidthGB:                   portBandwidthGB,
 				Verbose:                           true,
 			},
 		},
@@ -125,7 +125,6 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 			config.Config{
 				PodName:                          testPodName,
 				PodUID:                           testPodUID,
-				PortBandwidthGB:                  portBandwidthGB,
 				NetworkAttachmentDefinitionName:  networkAttachmentDefinitionName,
 				TrafficGeneratorImage:            trafficGeneratorImage,
 				TrafficGeneratorPacketsPerSecond: trafficGeneratorPacketsPerSecond,
@@ -135,6 +134,7 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				DPDKEastMacAddress:               dpdkEastHWAddress,
 				DPDKWestMacAddress:               dpdkWestHWAddress,
 				TestDuration:                     30 * time.Minute,
+				PortBandwidthGB:                  portBandwidthGB,
 				Verbose:                          true,
 			},
 		},

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -46,8 +46,8 @@ const (
 	dpdkNodeLabelSelector             = "node-role.kubernetes.io/worker-dpdk2"
 	dpdkEastMacAddress                = "DE:AD:BE:EF:00:02"
 	dpdkWestMacAddress                = "DE:AD:BE:EF:02:00"
-	portBandwidthGB                   = 100
 	testDuration                      = "30m"
+	portBandwidthGB                   = 100
 )
 
 func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
@@ -78,8 +78,8 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		VMContainerDiskImage:             config.VMContainerDiskImageDefault,
 		DPDKEastMacAddress:               actualConfig.DPDKEastMacAddress,
 		DPDKWestMacAddress:               actualConfig.DPDKWestMacAddress,
-		PortBandwidthGB:                  config.PortBandwidthGBDefault,
 		TestDuration:                     config.TestDurationDefault,
+		PortBandwidthGB:                  config.PortBandwidthGBDefault,
 		Verbose:                          config.VerboseDefault,
 	}
 	assert.Equal(t, expectedConfig, actualConfig)
@@ -219,16 +219,16 @@ func TestNewShouldFailWhen(t *testing.T) {
 			expectedError:  config.ErrInvalidDPDKWestMacAddress,
 		},
 		{
-			description:    "PortBandwidthGB is invalid",
-			key:            config.PortBandwidthGBParamName,
-			faultyKeyValue: "0",
-			expectedError:  config.ErrInvalidPortBandwidthGB,
-		},
-		{
 			description:    "TestDuration is invalid",
 			key:            config.TestDurationParamName,
 			faultyKeyValue: "invalid value",
 			expectedError:  config.ErrInvalidTestDuration,
+		},
+		{
+			description:    "PortBandwidthGB is invalid",
+			key:            config.PortBandwidthGBParamName,
+			faultyKeyValue: "0",
+			expectedError:  config.ErrInvalidPortBandwidthGB,
 		},
 		{
 			description:    "Verbose is invalid",
@@ -282,8 +282,8 @@ func getValidUserParameters() map[string]string {
 		config.DPDKNodeLabelSelectorParamName:             dpdkNodeLabelSelector,
 		config.DPDKEastMacAddressParamName:                dpdkEastMacAddress,
 		config.DPDKWestMacAddressParamName:                dpdkWestMacAddress,
-		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.TestDurationParamName:                      testDuration,
+		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.VerboseParamName:                           strconv.FormatBool(true),
 	}
 }

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -43,8 +43,8 @@ const (
 	trafficGeneratorEastMacAddress    = "DE:AD:BE:EF:00:01"
 	trafficGeneratorWestMacAddress    = "DE:AD:BE:EF:01:00"
 	vmContainerDiskImage              = "quay.io/ramlavi/kubevirt-dpdk-checkup-vm:main"
-	portBandwidthGB                   = 100
 	dpdkNodeLabelSelector             = "node-role.kubernetes.io/worker-dpdk2"
+	portBandwidthGB                   = 100
 	dpdkEastMacAddress                = "DE:AD:BE:EF:00:02"
 	dpdkWestMacAddress                = "DE:AD:BE:EF:02:00"
 	testDuration                      = "30m"
@@ -279,8 +279,8 @@ func getValidUserParameters() map[string]string {
 		config.TrafficGeneratorEastMacAddressParamName:    trafficGeneratorEastMacAddress,
 		config.TrafficGeneratorWestMacAddressParamName:    trafficGeneratorWestMacAddress,
 		config.VMContainerDiskImageParamName:              vmContainerDiskImage,
-		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.DPDKNodeLabelSelectorParamName:             dpdkNodeLabelSelector,
+		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.DPDKEastMacAddressParamName:                dpdkEastMacAddress,
 		config.DPDKWestMacAddressParamName:                dpdkWestMacAddress,
 		config.TestDurationParamName:                      testDuration,

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -37,6 +37,7 @@ const (
 	testPodName                       = "my-pod"
 	testPodUID                        = "0123456789-0123456789"
 	networkAttachmentDefinitionName   = "intel-dpdk-network1"
+	trafficGeneratorImage             = "quay.io/ramlavi/kubevirt-dpdk-checkup-traffic-gen:main"
 	portBandwidthGB                   = 100
 	trafficGeneratorNodeLabelSelector = "node-role.kubernetes.io/worker-dpdk1"
 	trafficGeneratorPacketsPerSecond  = "6m"
@@ -45,7 +46,6 @@ const (
 	trafficGeneratorWestMacAddress    = "DE:AD:BE:EF:01:00"
 	dpdkEastMacAddress                = "DE:AD:BE:EF:00:02"
 	dpdkWestMacAddress                = "DE:AD:BE:EF:02:00"
-	trafficGeneratorImage             = "quay.io/ramlavi/kubevirt-dpdk-checkup-traffic-gen:main"
 	vmContainerDiskImage              = "quay.io/ramlavi/kubevirt-dpdk-checkup-vm:main"
 	testDuration                      = "30m"
 )
@@ -71,13 +71,13 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		PodName:                          testPodName,
 		PodUID:                           testPodUID,
 		NetworkAttachmentDefinitionName:  networkAttachmentDefinitionName,
+		TrafficGeneratorImage:            config.TrafficGeneratorImageDefault,
 		TrafficGeneratorPacketsPerSecond: config.TrafficGeneratorPacketsPerSecondDefault,
 		PortBandwidthGB:                  config.PortBandwidthGBDefault,
 		TrafficGeneratorEastMacAddress:   actualConfig.TrafficGeneratorEastMacAddress,
 		TrafficGeneratorWestMacAddress:   actualConfig.TrafficGeneratorWestMacAddress,
 		DPDKEastMacAddress:               actualConfig.DPDKEastMacAddress,
 		DPDKWestMacAddress:               actualConfig.DPDKWestMacAddress,
-		TrafficGeneratorImage:            config.TrafficGeneratorImageDefault,
 		VMContainerDiskImage:             config.VMContainerDiskImageDefault,
 		TestDuration:                     config.TestDurationDefault,
 		Verbose:                          config.VerboseDefault,
@@ -106,6 +106,7 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				PodUID:                            testPodUID,
 				PortBandwidthGB:                   portBandwidthGB,
 				NetworkAttachmentDefinitionName:   networkAttachmentDefinitionName,
+				TrafficGeneratorImage:             trafficGeneratorImage,
 				TrafficGeneratorPacketsPerSecond:  trafficGeneratorPacketsPerSecond,
 				TrafficGeneratorNodeLabelSelector: trafficGeneratorNodeLabelSelector,
 				DPDKNodeLabelSelector:             dpdkNodeLabelSelector,
@@ -113,7 +114,6 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				TrafficGeneratorWestMacAddress:    trafficGeneratorWestHWAddress,
 				DPDKEastMacAddress:                dpdkEastHWAddress,
 				DPDKWestMacAddress:                dpdkWestHWAddress,
-				TrafficGeneratorImage:             trafficGeneratorImage,
 				VMContainerDiskImage:              vmContainerDiskImage,
 				TestDuration:                      30 * time.Minute,
 				Verbose:                           true,
@@ -127,12 +127,12 @@ func TestNewShouldApplyUserConfigWhen(t *testing.T) {
 				PodUID:                           testPodUID,
 				PortBandwidthGB:                  portBandwidthGB,
 				NetworkAttachmentDefinitionName:  networkAttachmentDefinitionName,
+				TrafficGeneratorImage:            trafficGeneratorImage,
 				TrafficGeneratorPacketsPerSecond: trafficGeneratorPacketsPerSecond,
 				TrafficGeneratorEastMacAddress:   trafficGeneratorEastHWAddress,
 				TrafficGeneratorWestMacAddress:   trafficGeneratorWestHWAddress,
 				DPDKEastMacAddress:               dpdkEastHWAddress,
 				DPDKWestMacAddress:               dpdkWestHWAddress,
-				TrafficGeneratorImage:            trafficGeneratorImage,
 				VMContainerDiskImage:             vmContainerDiskImage,
 				TestDuration:                     30 * time.Minute,
 				Verbose:                          true,
@@ -273,6 +273,7 @@ func getValidUserParametersWithOutNodeSelectors() map[string]string {
 func getValidUserParameters() map[string]string {
 	return map[string]string{
 		config.NetworkAttachmentDefinitionNameParamName:   networkAttachmentDefinitionName,
+		config.TrafficGeneratorImageParamName:             trafficGeneratorImage,
 		config.PortBandwidthGBParamName:                   fmt.Sprintf("%d", portBandwidthGB),
 		config.TrafficGeneratorNodeLabelSelectorParamName: trafficGeneratorNodeLabelSelector,
 		config.TrafficGeneratorPacketsPerSecondParamName:  trafficGeneratorPacketsPerSecond,
@@ -281,7 +282,6 @@ func getValidUserParameters() map[string]string {
 		config.TrafficGeneratorWestMacAddressParamName:    trafficGeneratorWestMacAddress,
 		config.DPDKEastMacAddressParamName:                dpdkEastMacAddress,
 		config.DPDKWestMacAddressParamName:                dpdkWestMacAddress,
-		config.TrafficGeneratorImageParamName:             trafficGeneratorImage,
 		config.VMContainerDiskImageParamName:              vmContainerDiskImage,
 		config.TestDurationParamName:                      testDuration,
 		config.VerboseParamName:                           strconv.FormatBool(true),


### PR DESCRIPTION
In order to change the user-facing API in a follow-up PR, align the config fields' place with their place in the README.

It helps to differentiate between:
1. Traffic gen related fields.
2. VMI under test related fields.
3. Shared fields.