### PR TITLE
Reporter: Align output field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 | status.result.vmUnderTestActualNodeName    | Node name on which the VM under test was scheduled                |          |
 | status.result.vmUnderTestReceivedPackets   | Number of packets packets received on the VM under test           |          |
 | status.result.vmUnderTestRxDroppedPackets  | Indicates ingress packets that were dropped from DPDK application |          |
-| status.result.DPDKTxPacketDrops            | Indicates egress packets were dropped from the DPDK application   |          |
+| status.result.vmUnderTestTxDroppedPackets  | Indicates egress packets were dropped from the DPDK application   |          |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 | status.result.trafficGenOutputErrorPackets | Indicates error sending packets from traffic generator            |          |
 | status.result.trafficGenInputErrorPackets  | Indicates error receiving packets to traffic generator            |          |
 | status.result.trafficGenActualNodeName     | Node name on which the traffic generator VM was scheduled         |          |
-| status.result.DPDKVMNode                   | Node name on which the DPDK VMI was scheduled                     |          |
+| status.result.vmUnderTestActualNodeName    | Node name on which the VM under test was scheduled                |          |
 | status.result.DPDKRxTestPackets            | Number of packets packets received on the DPDK VMI                |          |
 | status.result.DPDKRxPacketDrops            | Indicates ingress packets that were dropped from DPDK application |          |
 | status.result.DPDKTxPacketDrops            | Indicates egress packets were dropped from the DPDK application   |          |

--- a/README.md
+++ b/README.md
@@ -146,6 +146,6 @@ kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 | status.result.trafficGenInputErrorPackets  | Indicates error receiving packets to traffic generator            |          |
 | status.result.trafficGenActualNodeName     | Node name on which the traffic generator VM was scheduled         |          |
 | status.result.vmUnderTestActualNodeName    | Node name on which the VM under test was scheduled                |          |
-| status.result.DPDKRxTestPackets            | Number of packets packets received on the DPDK VMI                |          |
+| status.result.vmUnderTestReceivedPackets   | Number of packets packets received on the VM under test           |          |
 | status.result.DPDKRxPacketDrops            | Indicates ingress packets that were dropped from DPDK application |          |
 | status.result.DPDKTxPacketDrops            | Indicates egress packets were dropped from the DPDK application   |          |

--- a/README.md
+++ b/README.md
@@ -135,17 +135,17 @@ After the checkup Job had completed, the results are made available at the user-
 kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 ```
 
-| Key                                              | Description                                                       | Remarks  |
-|--------------------------------------------------|-------------------------------------------------------------------|----------|
-| status.succeeded                                 | Has the checkup succeeded                                         |          |
-| status.failureReason                             | Failure reason in case of a failure                               |          |
-| status.startTimestamp                            | Checkup start timestamp                                           | RFC 3339 |
-| status.completionTimestamp                       | Checkup completion timestamp                                      | RFC 3339 |
-| status.result.trafficGenSentPackets              | Number of packets sent from the traffic generator                 |          |
-| status.result.trafficGeneratorOutputErrorPackets | Indicates error sending packets from traffic generator            |          |
-| status.result.trafficGeneratorInErrorPackets     | Indicates error receiving packets to traffic generator            |          |
-| status.result.trafficGeneratorNode               | Node name on which the traffic generator VM was scheduled         |          |
-| status.result.DPDKVMNode                         | Node name on which the DPDK VMI was scheduled                     |          |
-| status.result.DPDKRxTestPackets                  | Number of packets packets received on the DPDK VMI                |          |
-| status.result.DPDKRxPacketDrops                  | Indicates ingress packets that were dropped from DPDK application |          |
-| status.result.DPDKTxPacketDrops                  | Indicates egress packets were dropped from the DPDK application   |          |
+| Key                                          | Description                                                       | Remarks  |
+|----------------------------------------------|-------------------------------------------------------------------|----------|
+| status.succeeded                             | Has the checkup succeeded                                         |          |
+| status.failureReason                         | Failure reason in case of a failure                               |          |
+| status.startTimestamp                        | Checkup start timestamp                                           | RFC 3339 |
+| status.completionTimestamp                   | Checkup completion timestamp                                      | RFC 3339 |
+| status.result.trafficGenSentPackets          | Number of packets sent from the traffic generator                 |          |
+| status.result.trafficGenOutputErrorPackets   | Indicates error sending packets from traffic generator            |          |
+| status.result.trafficGeneratorInErrorPackets | Indicates error receiving packets to traffic generator            |          |
+| status.result.trafficGeneratorNode           | Node name on which the traffic generator VM was scheduled         |          |
+| status.result.DPDKVMNode                     | Node name on which the DPDK VMI was scheduled                     |          |
+| status.result.DPDKRxTestPackets              | Number of packets packets received on the DPDK VMI                |          |
+| status.result.DPDKRxPacketDrops              | Indicates ingress packets that were dropped from DPDK application |          |
+| status.result.DPDKTxPacketDrops              | Indicates egress packets were dropped from the DPDK application   |          |

--- a/README.md
+++ b/README.md
@@ -135,17 +135,17 @@ After the checkup Job had completed, the results are made available at the user-
 kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 ```
 
-| Key                                          | Description                                                       | Remarks  |
-|----------------------------------------------|-------------------------------------------------------------------|----------|
-| status.succeeded                             | Has the checkup succeeded                                         |          |
-| status.failureReason                         | Failure reason in case of a failure                               |          |
-| status.startTimestamp                        | Checkup start timestamp                                           | RFC 3339 |
-| status.completionTimestamp                   | Checkup completion timestamp                                      | RFC 3339 |
-| status.result.trafficGenSentPackets          | Number of packets sent from the traffic generator                 |          |
-| status.result.trafficGenOutputErrorPackets   | Indicates error sending packets from traffic generator            |          |
-| status.result.trafficGeneratorInErrorPackets | Indicates error receiving packets to traffic generator            |          |
-| status.result.trafficGeneratorNode           | Node name on which the traffic generator VM was scheduled         |          |
-| status.result.DPDKVMNode                     | Node name on which the DPDK VMI was scheduled                     |          |
-| status.result.DPDKRxTestPackets              | Number of packets packets received on the DPDK VMI                |          |
-| status.result.DPDKRxPacketDrops              | Indicates ingress packets that were dropped from DPDK application |          |
-| status.result.DPDKTxPacketDrops              | Indicates egress packets were dropped from the DPDK application   |          |
+| Key                                        | Description                                                       | Remarks  |
+|--------------------------------------------|-------------------------------------------------------------------|----------|
+| status.succeeded                           | Has the checkup succeeded                                         |          |
+| status.failureReason                       | Failure reason in case of a failure                               |          |
+| status.startTimestamp                      | Checkup start timestamp                                           | RFC 3339 |
+| status.completionTimestamp                 | Checkup completion timestamp                                      | RFC 3339 |
+| status.result.trafficGenSentPackets        | Number of packets sent from the traffic generator                 |          |
+| status.result.trafficGenOutputErrorPackets | Indicates error sending packets from traffic generator            |          |
+| status.result.trafficGenInputErrorPackets  | Indicates error receiving packets to traffic generator            |          |
+| status.result.trafficGeneratorNode         | Node name on which the traffic generator VM was scheduled         |          |
+| status.result.DPDKVMNode                   | Node name on which the DPDK VMI was scheduled                     |          |
+| status.result.DPDKRxTestPackets            | Number of packets packets received on the DPDK VMI                |          |
+| status.result.DPDKRxPacketDrops            | Indicates ingress packets that were dropped from DPDK application |          |
+| status.result.DPDKTxPacketDrops            | Indicates egress packets were dropped from the DPDK application   |          |

--- a/README.md
+++ b/README.md
@@ -147,5 +147,5 @@ kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 | status.result.trafficGenActualNodeName     | Node name on which the traffic generator VM was scheduled         |          |
 | status.result.vmUnderTestActualNodeName    | Node name on which the VM under test was scheduled                |          |
 | status.result.vmUnderTestReceivedPackets   | Number of packets packets received on the VM under test           |          |
-| status.result.DPDKRxPacketDrops            | Indicates ingress packets that were dropped from DPDK application |          |
+| status.result.vmUnderTestRxDroppedPackets  | Indicates ingress packets that were dropped from DPDK application |          |
 | status.result.DPDKTxPacketDrops            | Indicates egress packets were dropped from the DPDK application   |          |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 | status.result.trafficGenSentPackets        | Number of packets sent from the traffic generator                 |          |
 | status.result.trafficGenOutputErrorPackets | Indicates error sending packets from traffic generator            |          |
 | status.result.trafficGenInputErrorPackets  | Indicates error receiving packets to traffic generator            |          |
-| status.result.trafficGeneratorNode         | Node name on which the traffic generator VM was scheduled         |          |
+| status.result.trafficGenActualNodeName     | Node name on which the traffic generator VM was scheduled         |          |
 | status.result.DPDKVMNode                   | Node name on which the DPDK VMI was scheduled                     |          |
 | status.result.DPDKRxTestPackets            | Number of packets packets received on the DPDK VMI                |          |
 | status.result.DPDKRxPacketDrops            | Indicates ingress packets that were dropped from DPDK application |          |

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ kubectl get configmap dpdk-checkup-config -n <target-namespace> -o yaml
 | status.failureReason                             | Failure reason in case of a failure                               |          |
 | status.startTimestamp                            | Checkup start timestamp                                           | RFC 3339 |
 | status.completionTimestamp                       | Checkup completion timestamp                                      | RFC 3339 |
-| status.result.trafficGeneratorTxPackets          | Number of packets sent from the traffic generator                 |          |
+| status.result.trafficGenSentPackets              | Number of packets sent from the traffic generator                 |          |
 | status.result.trafficGeneratorOutputErrorPackets | Indicates error sending packets from traffic generator            |          |
 | status.result.trafficGeneratorInErrorPackets     | Indicates error receiving packets to traffic generator            |          |
 | status.result.trafficGeneratorNode               | Node name on which the traffic generator VM was scheduled         |          |

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -137,7 +137,7 @@ func (c *Checkup) Run(ctx context.Context) error {
 		return err
 	}
 	c.results.DPDKVMNode = c.vmiUnderTest.Status.NodeName
-	c.results.TrafficGeneratorNode = c.trafficGen.Status.NodeName
+	c.results.TrafficGenActualNodeName = c.trafficGen.Status.NodeName
 
 	if c.results.TrafficGenOutputErrorPackets != 0 || c.results.TrafficGenInputErrorPackets != 0 {
 		return fmt.Errorf("detected Error Packets on the traffic generator's side: Oerrors %d Ierrors %d",

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -136,7 +136,7 @@ func (c *Checkup) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	c.results.DPDKVMNode = c.vmiUnderTest.Status.NodeName
+	c.results.VMUnderTestActualNodeName = c.vmiUnderTest.Status.NodeName
 	c.results.TrafficGenActualNodeName = c.trafficGen.Status.NodeName
 
 	if c.results.TrafficGenOutputErrorPackets != 0 || c.results.TrafficGenInputErrorPackets != 0 {

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -144,9 +144,9 @@ func (c *Checkup) Run(ctx context.Context) error {
 			c.results.TrafficGenOutputErrorPackets, c.results.TrafficGenInputErrorPackets)
 	}
 
-	if c.results.DPDKPacketsRxDropped != 0 || c.results.DPDKPacketsTxDropped != 0 {
+	if c.results.VMUnderTestRxDroppedPackets != 0 || c.results.DPDKPacketsTxDropped != 0 {
 		return fmt.Errorf("detected packets dropped on the DPDK VM's side: RX: %d; TX: %d",
-			c.results.DPDKPacketsRxDropped, c.results.DPDKPacketsTxDropped)
+			c.results.VMUnderTestRxDroppedPackets, c.results.DPDKPacketsTxDropped)
 	}
 
 	if c.results.TrafficGenSentPackets != c.results.VMUnderTestReceivedPackets {

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -144,9 +144,9 @@ func (c *Checkup) Run(ctx context.Context) error {
 			c.results.TrafficGenOutputErrorPackets, c.results.TrafficGenInputErrorPackets)
 	}
 
-	if c.results.VMUnderTestRxDroppedPackets != 0 || c.results.DPDKPacketsTxDropped != 0 {
+	if c.results.VMUnderTestRxDroppedPackets != 0 || c.results.VMUnderTestTxDroppedPackets != 0 {
 		return fmt.Errorf("detected packets dropped on the DPDK VM's side: RX: %d; TX: %d",
-			c.results.VMUnderTestRxDroppedPackets, c.results.DPDKPacketsTxDropped)
+			c.results.VMUnderTestRxDroppedPackets, c.results.VMUnderTestTxDroppedPackets)
 	}
 
 	if c.results.TrafficGenSentPackets != c.results.VMUnderTestReceivedPackets {

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -139,9 +139,9 @@ func (c *Checkup) Run(ctx context.Context) error {
 	c.results.DPDKVMNode = c.vmiUnderTest.Status.NodeName
 	c.results.TrafficGeneratorNode = c.trafficGen.Status.NodeName
 
-	if c.results.TrafficGenOutputErrorPackets != 0 || c.results.TrafficGeneratorInErrorPackets != 0 {
+	if c.results.TrafficGenOutputErrorPackets != 0 || c.results.TrafficGenInputErrorPackets != 0 {
 		return fmt.Errorf("detected Error Packets on the traffic generator's side: Oerrors %d Ierrors %d",
-			c.results.TrafficGenOutputErrorPackets, c.results.TrafficGeneratorInErrorPackets)
+			c.results.TrafficGenOutputErrorPackets, c.results.TrafficGenInputErrorPackets)
 	}
 
 	if c.results.DPDKPacketsRxDropped != 0 || c.results.DPDKPacketsTxDropped != 0 {

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -149,9 +149,9 @@ func (c *Checkup) Run(ctx context.Context) error {
 			c.results.DPDKPacketsRxDropped, c.results.DPDKPacketsTxDropped)
 	}
 
-	if c.results.TrafficGeneratorTxPackets != c.results.DPDKRxTestPackets {
+	if c.results.TrafficGenSentPackets != c.results.DPDKRxTestPackets {
 		return fmt.Errorf("not all generated packets had reached DPDK VM: Sent from traffic generator: %d; Received on DPDK VM: %d",
-			c.results.TrafficGeneratorTxPackets, c.results.DPDKRxTestPackets)
+			c.results.TrafficGenSentPackets, c.results.DPDKRxTestPackets)
 	}
 
 	return nil

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -139,9 +139,9 @@ func (c *Checkup) Run(ctx context.Context) error {
 	c.results.DPDKVMNode = c.vmiUnderTest.Status.NodeName
 	c.results.TrafficGeneratorNode = c.trafficGen.Status.NodeName
 
-	if c.results.TrafficGeneratorOutErrorPackets != 0 || c.results.TrafficGeneratorInErrorPackets != 0 {
+	if c.results.TrafficGenOutputErrorPackets != 0 || c.results.TrafficGeneratorInErrorPackets != 0 {
 		return fmt.Errorf("detected Error Packets on the traffic generator's side: Oerrors %d Ierrors %d",
-			c.results.TrafficGeneratorOutErrorPackets, c.results.TrafficGeneratorInErrorPackets)
+			c.results.TrafficGenOutputErrorPackets, c.results.TrafficGeneratorInErrorPackets)
 	}
 
 	if c.results.DPDKPacketsRxDropped != 0 || c.results.DPDKPacketsTxDropped != 0 {

--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -149,9 +149,9 @@ func (c *Checkup) Run(ctx context.Context) error {
 			c.results.DPDKPacketsRxDropped, c.results.DPDKPacketsTxDropped)
 	}
 
-	if c.results.TrafficGenSentPackets != c.results.DPDKRxTestPackets {
+	if c.results.TrafficGenSentPackets != c.results.VMUnderTestReceivedPackets {
 		return fmt.Errorf("not all generated packets had reached DPDK VM: Sent from traffic generator: %d; Received on DPDK VM: %d",
-			c.results.TrafficGenSentPackets, c.results.DPDKRxTestPackets)
+			c.results.TrafficGenSentPackets, c.results.VMUnderTestReceivedPackets)
 	}
 
 	return nil

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -173,9 +173,9 @@ func calculateStats(trexClient trex.Client, testpmdConsole *testpmd.TestpmdConso
 	results.DPDKPacketsRxDropped = testPmdStats[testpmd.StatsSummary].RXDropped
 	results.DPDKPacketsTxDropped = testPmdStats[testpmd.StatsSummary].TXDropped
 	log.Printf("DPDK side packets Dropped: Rx: %d; TX: %d", results.DPDKPacketsRxDropped, results.DPDKPacketsTxDropped)
-	results.DPDKRxTestPackets =
+	results.VMUnderTestReceivedPackets =
 		testPmdStats[testpmd.StatsSummary].RXTotal - testPmdStats[testpmd.StatsPort0].TXPackets - testPmdStats[testpmd.StatsPort1].RXPackets
-	log.Printf("DPDK side test packets received (including dropped, excluding non-related packets): %d", results.DPDKRxTestPackets)
+	log.Printf("DPDK side test packets received (including dropped, excluding non-related packets): %d", results.VMUnderTestReceivedPackets)
 
 	return results, nil
 }

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -171,8 +171,8 @@ func calculateStats(trexClient trex.Client, testpmdConsole *testpmd.TestpmdConso
 		return status.Results{}, err
 	}
 	results.VMUnderTestRxDroppedPackets = testPmdStats[testpmd.StatsSummary].RXDropped
-	results.DPDKPacketsTxDropped = testPmdStats[testpmd.StatsSummary].TXDropped
-	log.Printf("DPDK side packets Dropped: Rx: %d; TX: %d", results.VMUnderTestRxDroppedPackets, results.DPDKPacketsTxDropped)
+	results.VMUnderTestTxDroppedPackets = testPmdStats[testpmd.StatsSummary].TXDropped
+	log.Printf("DPDK side packets Dropped: Rx: %d; TX: %d", results.VMUnderTestRxDroppedPackets, results.VMUnderTestTxDroppedPackets)
 	results.VMUnderTestReceivedPackets =
 		testPmdStats[testpmd.StatsSummary].RXTotal - testPmdStats[testpmd.StatsPort0].TXPackets - testPmdStats[testpmd.StatsPort1].RXPackets
 	log.Printf("DPDK side test packets received (including dropped, excluding non-related packets): %d", results.VMUnderTestReceivedPackets)

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -162,8 +162,8 @@ func calculateStats(trexClient trex.Client, testpmdConsole *testpmd.TestpmdConso
 	log.Printf("traffic Generator port %d Packet output errors: %d", trex.SourcePort, results.TrafficGeneratorOutErrorPackets)
 	results.TrafficGeneratorInErrorPackets = trafficGeneratorDstPortStats.Result.Ierrors
 	log.Printf("traffic Generator port %d Packet output errors: %d", trex.DestPort, results.TrafficGeneratorInErrorPackets)
-	results.TrafficGeneratorTxPackets = trafficGeneratorSrcPortStats.Result.Opackets
-	log.Printf("traffic Generator packet sent via port %d: %d", trex.SourcePort, results.TrafficGeneratorTxPackets)
+	results.TrafficGenSentPackets = trafficGeneratorSrcPortStats.Result.Opackets
+	log.Printf("traffic Generator packet sent via port %d: %d", trex.SourcePort, results.TrafficGenSentPackets)
 
 	log.Printf("get testpmd stats in DPDK VMI...")
 	var testPmdStats [testpmd.StatsArraySize]testpmd.PortStats

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -170,9 +170,9 @@ func calculateStats(trexClient trex.Client, testpmdConsole *testpmd.TestpmdConso
 	if testPmdStats, err = testpmdConsole.GetStats(); err != nil {
 		return status.Results{}, err
 	}
-	results.DPDKPacketsRxDropped = testPmdStats[testpmd.StatsSummary].RXDropped
+	results.VMUnderTestRxDroppedPackets = testPmdStats[testpmd.StatsSummary].RXDropped
 	results.DPDKPacketsTxDropped = testPmdStats[testpmd.StatsSummary].TXDropped
-	log.Printf("DPDK side packets Dropped: Rx: %d; TX: %d", results.DPDKPacketsRxDropped, results.DPDKPacketsTxDropped)
+	log.Printf("DPDK side packets Dropped: Rx: %d; TX: %d", results.VMUnderTestRxDroppedPackets, results.DPDKPacketsTxDropped)
 	results.VMUnderTestReceivedPackets =
 		testPmdStats[testpmd.StatsSummary].RXTotal - testPmdStats[testpmd.StatsPort0].TXPackets - testPmdStats[testpmd.StatsPort1].RXPackets
 	log.Printf("DPDK side test packets received (including dropped, excluding non-related packets): %d", results.VMUnderTestReceivedPackets)

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -158,8 +158,8 @@ func calculateStats(trexClient trex.Client, testpmdConsole *testpmd.TestpmdConso
 		return status.Results{}, err
 	}
 
-	results.TrafficGeneratorOutErrorPackets = trafficGeneratorSrcPortStats.Result.Oerrors
-	log.Printf("traffic Generator port %d Packet output errors: %d", trex.SourcePort, results.TrafficGeneratorOutErrorPackets)
+	results.TrafficGenOutputErrorPackets = trafficGeneratorSrcPortStats.Result.Oerrors
+	log.Printf("traffic Generator port %d Packet output errors: %d", trex.SourcePort, results.TrafficGenOutputErrorPackets)
 	results.TrafficGeneratorInErrorPackets = trafficGeneratorDstPortStats.Result.Ierrors
 	log.Printf("traffic Generator port %d Packet output errors: %d", trex.DestPort, results.TrafficGeneratorInErrorPackets)
 	results.TrafficGenSentPackets = trafficGeneratorSrcPortStats.Result.Opackets

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -160,8 +160,8 @@ func calculateStats(trexClient trex.Client, testpmdConsole *testpmd.TestpmdConso
 
 	results.TrafficGenOutputErrorPackets = trafficGeneratorSrcPortStats.Result.Oerrors
 	log.Printf("traffic Generator port %d Packet output errors: %d", trex.SourcePort, results.TrafficGenOutputErrorPackets)
-	results.TrafficGeneratorInErrorPackets = trafficGeneratorDstPortStats.Result.Ierrors
-	log.Printf("traffic Generator port %d Packet output errors: %d", trex.DestPort, results.TrafficGeneratorInErrorPackets)
+	results.TrafficGenInputErrorPackets = trafficGeneratorDstPortStats.Result.Ierrors
+	log.Printf("traffic Generator port %d Packet output errors: %d", trex.DestPort, results.TrafficGenInputErrorPackets)
 	results.TrafficGenSentPackets = trafficGeneratorSrcPortStats.Result.Opackets
 	log.Printf("traffic Generator packet sent via port %d: %d", trex.SourcePort, results.TrafficGenSentPackets)
 

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -35,7 +35,7 @@ const (
 	TrafficGenInputErrorPacketsKey  = "trafficGenInputErrorPackets"
 	VMUnderTestReceivedPacketsKey   = "vmUnderTestReceivedPackets"
 	VMUnderTestRxDroppedPacketsKey  = "vmUnderTestRxDroppedPackets"
-	DPDKTxDropsKey                  = "DPDKTxPacketDrops"
+	VMUnderTestTxDroppedPacketsKey  = "vmUnderTestTxDroppedPackets"
 	TrafficGenActualNodeNameKey     = "trafficGenActualNodeName"
 	VMUnderTestActualNodeNameKey    = "vmUnderTestActualNodeName"
 )
@@ -73,7 +73,7 @@ func formatResults(checkupStatus status.Status) map[string]string {
 		TrafficGenInputErrorPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.TrafficGenInputErrorPackets),
 		VMUnderTestReceivedPacketsKey:   fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestReceivedPackets),
 		VMUnderTestRxDroppedPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestRxDroppedPackets),
-		DPDKTxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
+		VMUnderTestTxDroppedPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestTxDroppedPackets),
 		TrafficGenActualNodeNameKey:     checkupStatus.Results.TrafficGenActualNodeName,
 		VMUnderTestActualNodeNameKey:    checkupStatus.Results.VMUnderTestActualNodeName,
 	}

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	TrafficGeneratorTxPacketsKey       = "trafficGeneratorTxPackets"
+	TrafficGenSentPacketsKey           = "trafficGenSentPackets"
 	TrafficGeneratorOutErrorPacketsKey = "trafficGeneratorOutputErrorPackets"
 	TrafficGeneratorInErrorPacketsKey  = "trafficGeneratorInErrorPackets"
 	DPDKRxTestPacketsKey               = "DPDKRxTestPackets"
@@ -68,7 +68,7 @@ func formatResults(checkupStatus status.Status) map[string]string {
 	}
 
 	formattedResults := map[string]string{
-		TrafficGeneratorTxPacketsKey:       fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorTxPackets),
+		TrafficGenSentPacketsKey:           fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
 		TrafficGeneratorOutErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
 		TrafficGeneratorInErrorPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorInErrorPackets),
 		DPDKRxTestPacketsKey:               fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -37,7 +37,7 @@ const (
 	DPDKRxDropsKey                  = "DPDKRxPacketDrops"
 	DPDKTxDropsKey                  = "DPDKTxPacketDrops"
 	TrafficGenActualNodeNameKey     = "trafficGenActualNodeName"
-	DPDKVMNodeKey                   = "DPDKVMNode"
+	VMUnderTestActualNodeNameKey    = "vmUnderTestActualNodeName"
 )
 
 type Reporter struct {
@@ -75,7 +75,7 @@ func formatResults(checkupStatus status.Status) map[string]string {
 		DPDKRxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 		DPDKTxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 		TrafficGenActualNodeNameKey:     checkupStatus.Results.TrafficGenActualNodeName,
-		DPDKVMNodeKey:                   checkupStatus.Results.DPDKVMNode,
+		VMUnderTestActualNodeNameKey:    checkupStatus.Results.VMUnderTestActualNodeName,
 	}
 
 	return formattedResults

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -33,7 +33,7 @@ const (
 	TrafficGenSentPacketsKey        = "trafficGenSentPackets"
 	TrafficGenOutputErrorPacketsKey = "trafficGenOutputErrorPackets"
 	TrafficGenInputErrorPacketsKey  = "trafficGenInputErrorPackets"
-	DPDKRxTestPacketsKey            = "DPDKRxTestPackets"
+	VMUnderTestReceivedPacketsKey   = "vmUnderTestReceivedPackets"
 	DPDKRxDropsKey                  = "DPDKRxPacketDrops"
 	DPDKTxDropsKey                  = "DPDKTxPacketDrops"
 	TrafficGenActualNodeNameKey     = "trafficGenActualNodeName"
@@ -71,7 +71,7 @@ func formatResults(checkupStatus status.Status) map[string]string {
 		TrafficGenSentPacketsKey:        fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
 		TrafficGenOutputErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
 		TrafficGenInputErrorPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.TrafficGenInputErrorPackets),
-		DPDKRxTestPacketsKey:            fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
+		VMUnderTestReceivedPacketsKey:   fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestReceivedPackets),
 		DPDKRxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 		DPDKTxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 		TrafficGenActualNodeNameKey:     checkupStatus.Results.TrafficGenActualNodeName,

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -30,14 +30,14 @@ import (
 )
 
 const (
-	TrafficGenSentPacketsKey          = "trafficGenSentPackets"
-	TrafficGenOutputErrorPacketsKey   = "trafficGenOutputErrorPackets"
-	TrafficGeneratorInErrorPacketsKey = "trafficGeneratorInErrorPackets"
-	DPDKRxTestPacketsKey              = "DPDKRxTestPackets"
-	DPDKRxDropsKey                    = "DPDKRxPacketDrops"
-	DPDKTxDropsKey                    = "DPDKTxPacketDrops"
-	TrafficGeneratorNodeKey           = "trafficGeneratorNode"
-	DPDKVMNodeKey                     = "DPDKVMNode"
+	TrafficGenSentPacketsKey        = "trafficGenSentPackets"
+	TrafficGenOutputErrorPacketsKey = "trafficGenOutputErrorPackets"
+	TrafficGenInputErrorPacketsKey  = "trafficGenInputErrorPackets"
+	DPDKRxTestPacketsKey            = "DPDKRxTestPackets"
+	DPDKRxDropsKey                  = "DPDKRxPacketDrops"
+	DPDKTxDropsKey                  = "DPDKTxPacketDrops"
+	TrafficGeneratorNodeKey         = "trafficGeneratorNode"
+	DPDKVMNodeKey                   = "DPDKVMNode"
 )
 
 type Reporter struct {
@@ -68,14 +68,14 @@ func formatResults(checkupStatus status.Status) map[string]string {
 	}
 
 	formattedResults := map[string]string{
-		TrafficGenSentPacketsKey:          fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
-		TrafficGenOutputErrorPacketsKey:   fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
-		TrafficGeneratorInErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorInErrorPackets),
-		DPDKRxTestPacketsKey:              fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
-		DPDKRxDropsKey:                    fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
-		DPDKTxDropsKey:                    fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
-		TrafficGeneratorNodeKey:           checkupStatus.Results.TrafficGeneratorNode,
-		DPDKVMNodeKey:                     checkupStatus.Results.DPDKVMNode,
+		TrafficGenSentPacketsKey:        fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
+		TrafficGenOutputErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
+		TrafficGenInputErrorPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.TrafficGenInputErrorPackets),
+		DPDKRxTestPacketsKey:            fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
+		DPDKRxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
+		DPDKTxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
+		TrafficGeneratorNodeKey:         checkupStatus.Results.TrafficGeneratorNode,
+		DPDKVMNodeKey:                   checkupStatus.Results.DPDKVMNode,
 	}
 
 	return formattedResults

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -30,14 +30,14 @@ import (
 )
 
 const (
-	TrafficGenSentPacketsKey           = "trafficGenSentPackets"
-	TrafficGeneratorOutErrorPacketsKey = "trafficGeneratorOutputErrorPackets"
-	TrafficGeneratorInErrorPacketsKey  = "trafficGeneratorInErrorPackets"
-	DPDKRxTestPacketsKey               = "DPDKRxTestPackets"
-	DPDKRxDropsKey                     = "DPDKRxPacketDrops"
-	DPDKTxDropsKey                     = "DPDKTxPacketDrops"
-	TrafficGeneratorNodeKey            = "trafficGeneratorNode"
-	DPDKVMNodeKey                      = "DPDKVMNode"
+	TrafficGenSentPacketsKey          = "trafficGenSentPackets"
+	TrafficGenOutputErrorPacketsKey   = "trafficGenOutputErrorPackets"
+	TrafficGeneratorInErrorPacketsKey = "trafficGeneratorInErrorPackets"
+	DPDKRxTestPacketsKey              = "DPDKRxTestPackets"
+	DPDKRxDropsKey                    = "DPDKRxPacketDrops"
+	DPDKTxDropsKey                    = "DPDKTxPacketDrops"
+	TrafficGeneratorNodeKey           = "trafficGeneratorNode"
+	DPDKVMNodeKey                     = "DPDKVMNode"
 )
 
 type Reporter struct {
@@ -68,14 +68,14 @@ func formatResults(checkupStatus status.Status) map[string]string {
 	}
 
 	formattedResults := map[string]string{
-		TrafficGenSentPacketsKey:           fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
-		TrafficGeneratorOutErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
-		TrafficGeneratorInErrorPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorInErrorPackets),
-		DPDKRxTestPacketsKey:               fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
-		DPDKRxDropsKey:                     fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
-		DPDKTxDropsKey:                     fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
-		TrafficGeneratorNodeKey:            checkupStatus.Results.TrafficGeneratorNode,
-		DPDKVMNodeKey:                      checkupStatus.Results.DPDKVMNode,
+		TrafficGenSentPacketsKey:          fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
+		TrafficGenOutputErrorPacketsKey:   fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
+		TrafficGeneratorInErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorInErrorPackets),
+		DPDKRxTestPacketsKey:              fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
+		DPDKRxDropsKey:                    fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
+		DPDKTxDropsKey:                    fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
+		TrafficGeneratorNodeKey:           checkupStatus.Results.TrafficGeneratorNode,
+		DPDKVMNodeKey:                     checkupStatus.Results.DPDKVMNode,
 	}
 
 	return formattedResults

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -36,7 +36,7 @@ const (
 	DPDKRxTestPacketsKey            = "DPDKRxTestPackets"
 	DPDKRxDropsKey                  = "DPDKRxPacketDrops"
 	DPDKTxDropsKey                  = "DPDKTxPacketDrops"
-	TrafficGeneratorNodeKey         = "trafficGeneratorNode"
+	TrafficGenActualNodeNameKey     = "trafficGenActualNodeName"
 	DPDKVMNodeKey                   = "DPDKVMNode"
 )
 
@@ -74,7 +74,7 @@ func formatResults(checkupStatus status.Status) map[string]string {
 		DPDKRxTestPacketsKey:            fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
 		DPDKRxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 		DPDKTxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
-		TrafficGeneratorNodeKey:         checkupStatus.Results.TrafficGeneratorNode,
+		TrafficGenActualNodeNameKey:     checkupStatus.Results.TrafficGenActualNodeName,
 		DPDKVMNodeKey:                   checkupStatus.Results.DPDKVMNode,
 	}
 

--- a/pkg/internal/reporter/reporter.go
+++ b/pkg/internal/reporter/reporter.go
@@ -34,7 +34,7 @@ const (
 	TrafficGenOutputErrorPacketsKey = "trafficGenOutputErrorPackets"
 	TrafficGenInputErrorPacketsKey  = "trafficGenInputErrorPackets"
 	VMUnderTestReceivedPacketsKey   = "vmUnderTestReceivedPackets"
-	DPDKRxDropsKey                  = "DPDKRxPacketDrops"
+	VMUnderTestRxDroppedPacketsKey  = "vmUnderTestRxDroppedPackets"
 	DPDKTxDropsKey                  = "DPDKTxPacketDrops"
 	TrafficGenActualNodeNameKey     = "trafficGenActualNodeName"
 	VMUnderTestActualNodeNameKey    = "vmUnderTestActualNodeName"
@@ -72,7 +72,7 @@ func formatResults(checkupStatus status.Status) map[string]string {
 		TrafficGenOutputErrorPacketsKey: fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
 		TrafficGenInputErrorPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.TrafficGenInputErrorPackets),
 		VMUnderTestReceivedPacketsKey:   fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestReceivedPackets),
-		DPDKRxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
+		VMUnderTestRxDroppedPacketsKey:  fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestRxDroppedPackets),
 		DPDKTxDropsKey:                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 		TrafficGenActualNodeNameKey:     checkupStatus.Results.TrafficGenActualNodeName,
 		VMUnderTestActualNodeNameKey:    checkupStatus.Results.VMUnderTestActualNodeName,

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -52,14 +52,14 @@ func TestReportShouldSucceed(t *testing.T) {
 
 func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 	const (
-		expectedTrafficGenSentPackets           = 0
-		expectedTrafficGeneratorOutErrorPackets = 0
-		expectedTrafficGeneratorInErrorPackets  = 0
-		expectedDPDKRxTestPackets               = 0
-		expectedDPDKPacketsRxDropped            = 0
-		expectedDPDKPacketsTxDropped            = 0
-		expectedDPDKVMNode                      = "dpdk-node01"
-		expectedTrafficGeneratorNode            = "dpdk-node02"
+		expectedTrafficGenSentPackets          = 0
+		expectedTrafficGenOutputErrorPackets   = 0
+		expectedTrafficGeneratorInErrorPackets = 0
+		expectedDPDKRxTestPackets              = 0
+		expectedDPDKPacketsRxDropped           = 0
+		expectedDPDKPacketsTxDropped           = 0
+		expectedDPDKVMNode                     = "dpdk-node01"
+		expectedTrafficGeneratorNode           = "dpdk-node02"
 	)
 
 	const (
@@ -78,31 +78,31 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		checkupStatus.FailureReason = []string{}
 		checkupStatus.CompletionTimestamp = time.Now()
 		checkupStatus.Results = status.Results{
-			TrafficGenSentPackets:           expectedTrafficGenSentPackets,
-			TrafficGeneratorOutErrorPackets: expectedTrafficGeneratorOutErrorPackets,
-			TrafficGeneratorInErrorPackets:  expectedTrafficGeneratorInErrorPackets,
-			DPDKRxTestPackets:               expectedDPDKRxTestPackets,
-			DPDKPacketsRxDropped:            expectedDPDKPacketsRxDropped,
-			DPDKPacketsTxDropped:            expectedDPDKPacketsTxDropped,
-			DPDKVMNode:                      expectedDPDKVMNode,
-			TrafficGeneratorNode:            expectedTrafficGeneratorNode,
+			TrafficGenSentPackets:          expectedTrafficGenSentPackets,
+			TrafficGenOutputErrorPackets:   expectedTrafficGenOutputErrorPackets,
+			TrafficGeneratorInErrorPackets: expectedTrafficGeneratorInErrorPackets,
+			DPDKRxTestPackets:              expectedDPDKRxTestPackets,
+			DPDKPacketsRxDropped:           expectedDPDKPacketsRxDropped,
+			DPDKPacketsTxDropped:           expectedDPDKPacketsTxDropped,
+			DPDKVMNode:                     expectedDPDKVMNode,
+			TrafficGeneratorNode:           expectedTrafficGeneratorNode,
 		}
 
 		assert.NoError(t, testReporter.Report(checkupStatus))
 
 		expectedReportData := map[string]string{
-			"status.succeeded":                                 strconv.FormatBool(true),
-			"status.failureReason":                             "",
-			"status.startTimestamp":                            timestamp(checkupStatus.StartTimestamp),
-			"status.completionTimestamp":                       timestamp(checkupStatus.CompletionTimestamp),
-			"status.result.trafficGenSentPackets":              fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
-			"status.result.trafficGeneratorOutputErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
-			"status.result.trafficGeneratorInErrorPackets":     fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
-			"status.result.DPDKRxTestPackets":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
-			"status.result.DPDKRxPacketDrops":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
-			"status.result.DPDKTxPacketDrops":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
-			"status.result.trafficGeneratorNode":               checkupStatus.Results.TrafficGeneratorNode,
-			"status.result.DPDKVMNode":                         checkupStatus.Results.DPDKVMNode,
+			"status.succeeded":                             strconv.FormatBool(true),
+			"status.failureReason":                         "",
+			"status.startTimestamp":                        timestamp(checkupStatus.StartTimestamp),
+			"status.completionTimestamp":                   timestamp(checkupStatus.CompletionTimestamp),
+			"status.result.trafficGenSentPackets":          fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
+			"status.result.trafficGenOutputErrorPackets":   fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
+			"status.result.trafficGeneratorInErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorInErrorPackets),
+			"status.result.DPDKRxTestPackets":              fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
+			"status.result.DPDKRxPacketDrops":              fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
+			"status.result.DPDKTxPacketDrops":              fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
+			"status.result.trafficGeneratorNode":           checkupStatus.Results.TrafficGeneratorNode,
+			"status.result.DPDKVMNode":                     checkupStatus.Results.DPDKVMNode,
 		}
 
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -52,14 +52,14 @@ func TestReportShouldSucceed(t *testing.T) {
 
 func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 	const (
-		expectedTrafficGenSentPackets          = 0
-		expectedTrafficGenOutputErrorPackets   = 0
-		expectedTrafficGeneratorInErrorPackets = 0
-		expectedDPDKRxTestPackets              = 0
-		expectedDPDKPacketsRxDropped           = 0
-		expectedDPDKPacketsTxDropped           = 0
-		expectedDPDKVMNode                     = "dpdk-node01"
-		expectedTrafficGeneratorNode           = "dpdk-node02"
+		expectedTrafficGenSentPackets        = 0
+		expectedTrafficGenOutputErrorPackets = 0
+		expectedTrafficGenInputErrorPackets  = 0
+		expectedDPDKRxTestPackets            = 0
+		expectedDPDKPacketsRxDropped         = 0
+		expectedDPDKPacketsTxDropped         = 0
+		expectedDPDKVMNode                   = "dpdk-node01"
+		expectedTrafficGeneratorNode         = "dpdk-node02"
 	)
 
 	const (
@@ -78,31 +78,31 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		checkupStatus.FailureReason = []string{}
 		checkupStatus.CompletionTimestamp = time.Now()
 		checkupStatus.Results = status.Results{
-			TrafficGenSentPackets:          expectedTrafficGenSentPackets,
-			TrafficGenOutputErrorPackets:   expectedTrafficGenOutputErrorPackets,
-			TrafficGeneratorInErrorPackets: expectedTrafficGeneratorInErrorPackets,
-			DPDKRxTestPackets:              expectedDPDKRxTestPackets,
-			DPDKPacketsRxDropped:           expectedDPDKPacketsRxDropped,
-			DPDKPacketsTxDropped:           expectedDPDKPacketsTxDropped,
-			DPDKVMNode:                     expectedDPDKVMNode,
-			TrafficGeneratorNode:           expectedTrafficGeneratorNode,
+			TrafficGenSentPackets:        expectedTrafficGenSentPackets,
+			TrafficGenOutputErrorPackets: expectedTrafficGenOutputErrorPackets,
+			TrafficGenInputErrorPackets:  expectedTrafficGenInputErrorPackets,
+			DPDKRxTestPackets:            expectedDPDKRxTestPackets,
+			DPDKPacketsRxDropped:         expectedDPDKPacketsRxDropped,
+			DPDKPacketsTxDropped:         expectedDPDKPacketsTxDropped,
+			DPDKVMNode:                   expectedDPDKVMNode,
+			TrafficGeneratorNode:         expectedTrafficGeneratorNode,
 		}
 
 		assert.NoError(t, testReporter.Report(checkupStatus))
 
 		expectedReportData := map[string]string{
-			"status.succeeded":                             strconv.FormatBool(true),
-			"status.failureReason":                         "",
-			"status.startTimestamp":                        timestamp(checkupStatus.StartTimestamp),
-			"status.completionTimestamp":                   timestamp(checkupStatus.CompletionTimestamp),
-			"status.result.trafficGenSentPackets":          fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
-			"status.result.trafficGenOutputErrorPackets":   fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
-			"status.result.trafficGeneratorInErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorInErrorPackets),
-			"status.result.DPDKRxTestPackets":              fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
-			"status.result.DPDKRxPacketDrops":              fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
-			"status.result.DPDKTxPacketDrops":              fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
-			"status.result.trafficGeneratorNode":           checkupStatus.Results.TrafficGeneratorNode,
-			"status.result.DPDKVMNode":                     checkupStatus.Results.DPDKVMNode,
+			"status.succeeded":                           strconv.FormatBool(true),
+			"status.failureReason":                       "",
+			"status.startTimestamp":                      timestamp(checkupStatus.StartTimestamp),
+			"status.completionTimestamp":                 timestamp(checkupStatus.CompletionTimestamp),
+			"status.result.trafficGenSentPackets":        fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
+			"status.result.trafficGenOutputErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
+			"status.result.trafficGenInputErrorPackets":  fmt.Sprintf("%d", checkupStatus.Results.TrafficGenInputErrorPackets),
+			"status.result.DPDKRxTestPackets":            fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
+			"status.result.DPDKRxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
+			"status.result.DPDKTxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
+			"status.result.trafficGeneratorNode":         checkupStatus.Results.TrafficGeneratorNode,
+			"status.result.DPDKVMNode":                   checkupStatus.Results.DPDKVMNode,
 		}
 
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -56,7 +56,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		expectedTrafficGenOutputErrorPackets = 0
 		expectedTrafficGenInputErrorPackets  = 0
 		expectedVMUnderTestReceivedPackets   = 0
-		expectedDPDKPacketsRxDropped         = 0
+		expectedVMUnderTestRxDroppedPackets  = 0
 		expectedDPDKPacketsTxDropped         = 0
 		expectedVMUnderTestActualNodeName    = "dpdk-node01"
 		expectedTrafficGenActualNodeName     = "dpdk-node02"
@@ -82,7 +82,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			TrafficGenOutputErrorPackets: expectedTrafficGenOutputErrorPackets,
 			TrafficGenInputErrorPackets:  expectedTrafficGenInputErrorPackets,
 			VMUnderTestReceivedPackets:   expectedVMUnderTestReceivedPackets,
-			DPDKPacketsRxDropped:         expectedDPDKPacketsRxDropped,
+			VMUnderTestRxDroppedPackets:  expectedVMUnderTestRxDroppedPackets,
 			DPDKPacketsTxDropped:         expectedDPDKPacketsTxDropped,
 			VMUnderTestActualNodeName:    expectedVMUnderTestActualNodeName,
 			TrafficGenActualNodeName:     expectedTrafficGenActualNodeName,
@@ -99,7 +99,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.trafficGenOutputErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
 			"status.result.trafficGenInputErrorPackets":  fmt.Sprintf("%d", checkupStatus.Results.TrafficGenInputErrorPackets),
 			"status.result.vmUnderTestReceivedPackets":   fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestReceivedPackets),
-			"status.result.DPDKRxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
+			"status.result.vmUnderTestRxDroppedPackets":  fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestRxDroppedPackets),
 			"status.result.DPDKTxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 			"status.result.trafficGenActualNodeName":     checkupStatus.Results.TrafficGenActualNodeName,
 			"status.result.vmUnderTestActualNodeName":    checkupStatus.Results.VMUnderTestActualNodeName,

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -58,7 +58,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		expectedDPDKRxTestPackets            = 0
 		expectedDPDKPacketsRxDropped         = 0
 		expectedDPDKPacketsTxDropped         = 0
-		expectedDPDKVMNode                   = "dpdk-node01"
+		expectedVMUnderTestActualNodeName    = "dpdk-node01"
 		expectedTrafficGenActualNodeName     = "dpdk-node02"
 	)
 
@@ -84,7 +84,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			DPDKRxTestPackets:            expectedDPDKRxTestPackets,
 			DPDKPacketsRxDropped:         expectedDPDKPacketsRxDropped,
 			DPDKPacketsTxDropped:         expectedDPDKPacketsTxDropped,
-			DPDKVMNode:                   expectedDPDKVMNode,
+			VMUnderTestActualNodeName:    expectedVMUnderTestActualNodeName,
 			TrafficGenActualNodeName:     expectedTrafficGenActualNodeName,
 		}
 
@@ -102,7 +102,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.DPDKRxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 			"status.result.DPDKTxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 			"status.result.trafficGenActualNodeName":     checkupStatus.Results.TrafficGenActualNodeName,
-			"status.result.DPDKVMNode":                   checkupStatus.Results.DPDKVMNode,
+			"status.result.vmUnderTestActualNodeName":    checkupStatus.Results.VMUnderTestActualNodeName,
 		}
 
 		assert.Equal(t, expectedReportData, getCheckupData(t, fakeClient, testNamespace, testConfigMapName))

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -52,7 +52,7 @@ func TestReportShouldSucceed(t *testing.T) {
 
 func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 	const (
-		expectedTrafficGeneratorTxPackets       = 0
+		expectedTrafficGenSentPackets           = 0
 		expectedTrafficGeneratorOutErrorPackets = 0
 		expectedTrafficGeneratorInErrorPackets  = 0
 		expectedDPDKRxTestPackets               = 0
@@ -78,7 +78,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		checkupStatus.FailureReason = []string{}
 		checkupStatus.CompletionTimestamp = time.Now()
 		checkupStatus.Results = status.Results{
-			TrafficGeneratorTxPackets:       expectedTrafficGeneratorTxPackets,
+			TrafficGenSentPackets:           expectedTrafficGenSentPackets,
 			TrafficGeneratorOutErrorPackets: expectedTrafficGeneratorOutErrorPackets,
 			TrafficGeneratorInErrorPackets:  expectedTrafficGeneratorInErrorPackets,
 			DPDKRxTestPackets:               expectedDPDKRxTestPackets,
@@ -95,7 +95,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.failureReason":                             "",
 			"status.startTimestamp":                            timestamp(checkupStatus.StartTimestamp),
 			"status.completionTimestamp":                       timestamp(checkupStatus.CompletionTimestamp),
-			"status.result.trafficGeneratorTxPackets":          fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorTxPackets),
+			"status.result.trafficGenSentPackets":              fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
 			"status.result.trafficGeneratorOutputErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
 			"status.result.trafficGeneratorInErrorPackets":     fmt.Sprintf("%d", checkupStatus.Results.TrafficGeneratorOutErrorPackets),
 			"status.result.DPDKRxTestPackets":                  fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -59,7 +59,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		expectedDPDKPacketsRxDropped         = 0
 		expectedDPDKPacketsTxDropped         = 0
 		expectedDPDKVMNode                   = "dpdk-node01"
-		expectedTrafficGeneratorNode         = "dpdk-node02"
+		expectedTrafficGenActualNodeName     = "dpdk-node02"
 	)
 
 	const (
@@ -85,7 +85,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			DPDKPacketsRxDropped:         expectedDPDKPacketsRxDropped,
 			DPDKPacketsTxDropped:         expectedDPDKPacketsTxDropped,
 			DPDKVMNode:                   expectedDPDKVMNode,
-			TrafficGeneratorNode:         expectedTrafficGeneratorNode,
+			TrafficGenActualNodeName:     expectedTrafficGenActualNodeName,
 		}
 
 		assert.NoError(t, testReporter.Report(checkupStatus))
@@ -101,7 +101,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.DPDKRxTestPackets":            fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
 			"status.result.DPDKRxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 			"status.result.DPDKTxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
-			"status.result.trafficGeneratorNode":         checkupStatus.Results.TrafficGeneratorNode,
+			"status.result.trafficGenActualNodeName":     checkupStatus.Results.TrafficGenActualNodeName,
 			"status.result.DPDKVMNode":                   checkupStatus.Results.DPDKVMNode,
 		}
 

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -57,7 +57,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		expectedTrafficGenInputErrorPackets  = 0
 		expectedVMUnderTestReceivedPackets   = 0
 		expectedVMUnderTestRxDroppedPackets  = 0
-		expectedDPDKPacketsTxDropped         = 0
+		expectedVMUnderTestTxDroppedPackets  = 0
 		expectedVMUnderTestActualNodeName    = "dpdk-node01"
 		expectedTrafficGenActualNodeName     = "dpdk-node02"
 	)
@@ -83,7 +83,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			TrafficGenInputErrorPackets:  expectedTrafficGenInputErrorPackets,
 			VMUnderTestReceivedPackets:   expectedVMUnderTestReceivedPackets,
 			VMUnderTestRxDroppedPackets:  expectedVMUnderTestRxDroppedPackets,
-			DPDKPacketsTxDropped:         expectedDPDKPacketsTxDropped,
+			VMUnderTestTxDroppedPackets:  expectedVMUnderTestTxDroppedPackets,
 			VMUnderTestActualNodeName:    expectedVMUnderTestActualNodeName,
 			TrafficGenActualNodeName:     expectedTrafficGenActualNodeName,
 		}
@@ -100,7 +100,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.trafficGenInputErrorPackets":  fmt.Sprintf("%d", checkupStatus.Results.TrafficGenInputErrorPackets),
 			"status.result.vmUnderTestReceivedPackets":   fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestReceivedPackets),
 			"status.result.vmUnderTestRxDroppedPackets":  fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestRxDroppedPackets),
-			"status.result.DPDKTxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
+			"status.result.vmUnderTestTxDroppedPackets":  fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestTxDroppedPackets),
 			"status.result.trafficGenActualNodeName":     checkupStatus.Results.TrafficGenActualNodeName,
 			"status.result.vmUnderTestActualNodeName":    checkupStatus.Results.VMUnderTestActualNodeName,
 		}

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -55,7 +55,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 		expectedTrafficGenSentPackets        = 0
 		expectedTrafficGenOutputErrorPackets = 0
 		expectedTrafficGenInputErrorPackets  = 0
-		expectedDPDKRxTestPackets            = 0
+		expectedVMUnderTestReceivedPackets   = 0
 		expectedDPDKPacketsRxDropped         = 0
 		expectedDPDKPacketsTxDropped         = 0
 		expectedVMUnderTestActualNodeName    = "dpdk-node01"
@@ -81,7 +81,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			TrafficGenSentPackets:        expectedTrafficGenSentPackets,
 			TrafficGenOutputErrorPackets: expectedTrafficGenOutputErrorPackets,
 			TrafficGenInputErrorPackets:  expectedTrafficGenInputErrorPackets,
-			DPDKRxTestPackets:            expectedDPDKRxTestPackets,
+			VMUnderTestReceivedPackets:   expectedVMUnderTestReceivedPackets,
 			DPDKPacketsRxDropped:         expectedDPDKPacketsRxDropped,
 			DPDKPacketsTxDropped:         expectedDPDKPacketsTxDropped,
 			VMUnderTestActualNodeName:    expectedVMUnderTestActualNodeName,
@@ -98,7 +98,7 @@ func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 			"status.result.trafficGenSentPackets":        fmt.Sprintf("%d", checkupStatus.Results.TrafficGenSentPackets),
 			"status.result.trafficGenOutputErrorPackets": fmt.Sprintf("%d", checkupStatus.Results.TrafficGenOutputErrorPackets),
 			"status.result.trafficGenInputErrorPackets":  fmt.Sprintf("%d", checkupStatus.Results.TrafficGenInputErrorPackets),
-			"status.result.DPDKRxTestPackets":            fmt.Sprintf("%d", checkupStatus.Results.DPDKRxTestPackets),
+			"status.result.vmUnderTestReceivedPackets":   fmt.Sprintf("%d", checkupStatus.Results.VMUnderTestReceivedPackets),
 			"status.result.DPDKRxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsRxDropped),
 			"status.result.DPDKTxPacketDrops":            fmt.Sprintf("%d", checkupStatus.Results.DPDKPacketsTxDropped),
 			"status.result.trafficGenActualNodeName":     checkupStatus.Results.TrafficGenActualNodeName,

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -28,7 +28,7 @@ type Results struct {
 	DPDKRxTestPackets            int64
 	DPDKPacketsRxDropped         int64
 	DPDKPacketsTxDropped         int64
-	TrafficGeneratorNode         string
+	TrafficGenActualNodeName     string
 	DPDKVMNode                   string
 }
 

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -22,14 +22,14 @@ package status
 import kstatus "github.com/kiagnose/kiagnose/kiagnose/status"
 
 type Results struct {
-	TrafficGenSentPackets           int64
-	TrafficGeneratorOutErrorPackets int64
-	TrafficGeneratorInErrorPackets  int64
-	DPDKRxTestPackets               int64
-	DPDKPacketsRxDropped            int64
-	DPDKPacketsTxDropped            int64
-	TrafficGeneratorNode            string
-	DPDKVMNode                      string
+	TrafficGenSentPackets          int64
+	TrafficGenOutputErrorPackets   int64
+	TrafficGeneratorInErrorPackets int64
+	DPDKRxTestPackets              int64
+	DPDKPacketsRxDropped           int64
+	DPDKPacketsTxDropped           int64
+	TrafficGeneratorNode           string
+	DPDKVMNode                     string
 }
 
 type Status struct {

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -25,7 +25,7 @@ type Results struct {
 	TrafficGenSentPackets        int64
 	TrafficGenOutputErrorPackets int64
 	TrafficGenInputErrorPackets  int64
-	DPDKRxTestPackets            int64
+	VMUnderTestReceivedPackets   int64
 	DPDKPacketsRxDropped         int64
 	DPDKPacketsTxDropped         int64
 	TrafficGenActualNodeName     string

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -27,7 +27,7 @@ type Results struct {
 	TrafficGenInputErrorPackets  int64
 	VMUnderTestReceivedPackets   int64
 	VMUnderTestRxDroppedPackets  int64
-	DPDKPacketsTxDropped         int64
+	VMUnderTestTxDroppedPackets  int64
 	TrafficGenActualNodeName     string
 	VMUnderTestActualNodeName    string
 }

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -26,7 +26,7 @@ type Results struct {
 	TrafficGenOutputErrorPackets int64
 	TrafficGenInputErrorPackets  int64
 	VMUnderTestReceivedPackets   int64
-	DPDKPacketsRxDropped         int64
+	VMUnderTestRxDroppedPackets  int64
 	DPDKPacketsTxDropped         int64
 	TrafficGenActualNodeName     string
 	VMUnderTestActualNodeName    string

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -22,7 +22,7 @@ package status
 import kstatus "github.com/kiagnose/kiagnose/kiagnose/status"
 
 type Results struct {
-	TrafficGeneratorTxPackets       int64
+	TrafficGenSentPackets           int64
 	TrafficGeneratorOutErrorPackets int64
 	TrafficGeneratorInErrorPackets  int64
 	DPDKRxTestPackets               int64

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -29,7 +29,7 @@ type Results struct {
 	DPDKPacketsRxDropped         int64
 	DPDKPacketsTxDropped         int64
 	TrafficGenActualNodeName     string
-	DPDKVMNode                   string
+	VMUnderTestActualNodeName    string
 }
 
 type Status struct {

--- a/pkg/internal/status/status.go
+++ b/pkg/internal/status/status.go
@@ -22,14 +22,14 @@ package status
 import kstatus "github.com/kiagnose/kiagnose/kiagnose/status"
 
 type Results struct {
-	TrafficGenSentPackets          int64
-	TrafficGenOutputErrorPackets   int64
-	TrafficGeneratorInErrorPackets int64
-	DPDKRxTestPackets              int64
-	DPDKPacketsRxDropped           int64
-	DPDKPacketsTxDropped           int64
-	TrafficGeneratorNode           string
-	DPDKVMNode                     string
+	TrafficGenSentPackets        int64
+	TrafficGenOutputErrorPackets int64
+	TrafficGenInputErrorPackets  int64
+	DPDKRxTestPackets            int64
+	DPDKPacketsRxDropped         int64
+	DPDKPacketsTxDropped         int64
+	TrafficGeneratorNode         string
+	DPDKVMNode                   string
 }
 
 type Status struct {

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Execute the checkup Job", func() {
 		Expect(configMap.Data["status.failureReason"]).To(BeEmpty(), fmt.Sprintf("should be empty %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.result.DPDKVMNode"]).ToNot(BeEmpty(),
 			fmt.Sprintf("DPDKVMNode should not be empty %+v", prettifyData(configMap.Data)))
-		Expect(configMap.Data["status.result.trafficGeneratorNode"]).ToNot(BeEmpty(),
+		Expect(configMap.Data["status.result.trafficGenActualNodeName"]).ToNot(BeEmpty(),
 			fmt.Sprintf("trafficGeneratorNode should not be empty %+v", prettifyData(configMap.Data)))
 	})
 })

--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Execute the checkup Job", func() {
 		Expect(configMap.Data).NotTo(BeNil())
 		Expect(configMap.Data["status.succeeded"]).To(Equal("true"), fmt.Sprintf("should succeed %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.failureReason"]).To(BeEmpty(), fmt.Sprintf("should be empty %+v", prettifyData(configMap.Data)))
-		Expect(configMap.Data["status.result.DPDKVMNode"]).ToNot(BeEmpty(),
+		Expect(configMap.Data["status.result.vmUnderTestActualNodeName"]).ToNot(BeEmpty(),
 			fmt.Sprintf("DPDKVMNode should not be empty %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.result.trafficGenActualNodeName"]).ToNot(BeEmpty(),
 			fmt.Sprintf("trafficGeneratorNode should not be empty %+v", prettifyData(configMap.Data)))


### PR DESCRIPTION
Following PR #168, the input fields' names were improved.
Align the user-facing output fields to follow the prefixes defined in PR #168.

`trafficGeneratorTxPackets` -> `trafficGenSentPackets`
`trafficGeneratorOutputErrorPackets` -> `trafficGenOutputErrorPackets`
`trafficGeneratorInErrorPackets` -> `trafficGenInputErrorPackets`
`trafficGeneratorNode` -> `trafficGenActualNodeName`
`DPDKVMNode` -> `vmUnderTestActualNodeName`
`DPDKRxTestPackets` -> `vmUnderTestReceivedPackets`
`DPDKRxPacketDrops` -> `vmUnderTestRxDroppedPackets`
`DPDKTxPacketDrops` -> `vmUnderTestTxDroppedPackets`

Align the the internal field names as well.

~~This PR depends on PR #168, please review only the last eight commits.~~