### PR TITLE
console: Refactor package

### DIFF
--- a/pkg/internal/checkup/executor/console/console.go
+++ b/pkg/internal/checkup/executor/console/console.go
@@ -88,7 +88,7 @@ func RetValue(retcode string) string {
 // SafeExpectBatchWithResponse runs the batch from `expected`, connecting to a VMI's console and
 // waiting for the batch to return with a response until timeout.
 // It validates that the commands arrive to the console.
-// NOTE: This functions inherits limitations from `ExpectBatchWithValidatedSend`, refer to it for more information.
+// NOTE: This functions inherits limitations from `expectBatchWithValidatedSend`, refer to it for more information.
 func SafeExpectBatchWithResponse(serialConsoleClient vmiSerialConsoleClient,
 	vmiNamespace,
 	vmiName string,
@@ -100,28 +100,28 @@ func SafeExpectBatchWithResponse(serialConsoleClient vmiSerialConsoleClient,
 	}
 	defer expecter.Close()
 
-	resp, err := ExpectBatchWithValidatedSend(expecter, expected, timeout)
+	resp, err := expectBatchWithValidatedSend(expecter, expected, timeout)
 	if err != nil {
 		log.Printf("%v", resp)
 	}
 	return resp, err
 }
 
-// ExpectBatchWithValidatedSend adds the expect.BSnd command to the exect.BExp expression.
+// expectBatchWithValidatedSend adds the expect.BSnd command to the exect.BExp expression.
 // It is done to make sure the match was found in the result of the expect.BSnd
 // command and not in a leftover that wasn't removed from the buffer.
 // NOTE: the method contains the following limitations:
 //   - Use of `BatchSwitchCase`
 //   - Multiline commands
 //   - No more than one sequential send or receive
-func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batcher, timeout time.Duration) ([]expect.BatchRes, error) {
+func expectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batcher, timeout time.Duration) ([]expect.BatchRes, error) {
 	sendFlag := false
 	expectFlag := false
 	previousSend := ""
 
 	const minimumRequiredBatches = 2
 	if len(batch) < minimumRequiredBatches {
-		return nil, fmt.Errorf("ExpectBatchWithValidatedSend requires at least 2 batchers, supplied %v", batch)
+		return nil, fmt.Errorf("expectBatchWithValidatedSend requires at least 2 batchers, supplied %v", batch)
 	}
 
 	for i, batcher := range batch {
@@ -133,7 +133,7 @@ func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 			expectFlag = true
 			sendFlag = false
 			if _, ok := batch[i].(*expect.BExp); !ok {
-				return nil, fmt.Errorf("ExpectBatchWithValidatedSend support only expect of type BExp")
+				return nil, fmt.Errorf("expectBatchWithValidatedSend support only expect of type BExp")
 			}
 			bExp, _ := batch[i].(*expect.BExp)
 			previousSend = regexp.QuoteMeta(previousSend)
@@ -149,9 +149,9 @@ func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 			expectFlag = false
 			previousSend = batcher.Arg()
 		case expect.BatchSwitchCase:
-			return nil, fmt.Errorf("ExpectBatchWithValidatedSend doesn't support BatchSwitchCase")
+			return nil, fmt.Errorf("expectBatchWithValidatedSend doesn't support BatchSwitchCase")
 		default:
-			return nil, fmt.Errorf("unknown command: ExpectBatchWithValidatedSend supports only BatchExpect and BatchSend")
+			return nil, fmt.Errorf("unknown command: expectBatchWithValidatedSend supports only BatchExpect and BatchSend")
 		}
 	}
 

--- a/pkg/internal/checkup/executor/console/console.go
+++ b/pkg/internal/checkup/executor/console/console.go
@@ -105,13 +105,9 @@ func RetValue(retcode string) string {
 // waiting for the batch to return with a response until timeout.
 // It validates that the commands arrive to the console.
 // NOTE: This functions inherits limitations from `expectBatchWithValidatedSend`, refer to it for more information.
-func SafeExpectBatchWithResponse(serialConsoleClient vmiSerialConsoleClient,
-	vmiNamespace,
-	vmiName string,
-	expected []expect.Batcher,
+func (e Expecter) SafeExpectBatchWithResponse(expected []expect.Batcher,
 	timeout time.Duration) ([]expect.BatchRes, error) {
-	expecter := NewExpecter(serialConsoleClient, vmiNamespace, vmiName)
-	genExpect, err := expecter.spawnConsole(timeout)
+	genExpect, err := e.spawnConsole(timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/checkup/executor/console/console.go
+++ b/pkg/internal/checkup/executor/console/console.go
@@ -47,6 +47,14 @@ func NewExpecter(serialConsoleClient vmiSerialConsoleClient,
 	vmiName string,
 	timeout time.Duration,
 	opts ...expect.Option) (expect.Expecter, <-chan error, error) {
+	return spawnConsole(serialConsoleClient, vmiNamespace, vmiName, timeout, opts...)
+}
+
+func spawnConsole(serialConsoleClient vmiSerialConsoleClient,
+	vmiNamespace,
+	vmiName string,
+	timeout time.Duration,
+	opts ...expect.Option) (*expect.GExpect, <-chan error, error) {
 	vmiReader, vmiWriter := io.Pipe()
 	expecterReader, expecterWriter := io.Pipe()
 	resCh := make(chan error)

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -72,12 +72,14 @@ func New(client vmiSerialConsoleClient, namespace string, cfg config.Config) Exe
 
 func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMIName string) (status.Results, error) {
 	log.Printf("Login to VMI under test...")
-	if err := console.LoginToCentOS(e.vmiSerialClient, e.namespace, vmiUnderTestName, e.vmiUsername, e.vmiPassword); err != nil {
+	vmiUnderTestConsoleExpecter := console.NewExpecter(e.vmiSerialClient, e.namespace, vmiUnderTestName)
+	if err := vmiUnderTestConsoleExpecter.LoginToCentOS(e.vmiUsername, e.vmiPassword); err != nil {
 		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, vmiUnderTestName, err)
 	}
 
 	log.Printf("Login to traffic generator...")
-	if err := console.LoginToCentOS(e.vmiSerialClient, e.namespace, trafficGenVMIName, e.vmiUsername, e.vmiPassword); err != nil {
+	trafficGenConsoleExpecter := console.NewExpecter(e.vmiSerialClient, e.namespace, trafficGenVMIName)
+	if err := trafficGenConsoleExpecter.LoginToCentOS(e.vmiUsername, e.vmiPassword); err != nil {
 		return status.Results{}, fmt.Errorf("failed to login to VMI \"%s/%s\": %w", e.namespace, trafficGenVMIName, err)
 	}
 

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -84,9 +84,7 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 	}
 
 	trexClient := trex.NewClient(
-		e.vmiSerialClient,
-		e.namespace,
-		trafficGenVMIName,
+		trafficGenConsoleExpecter,
 		e.trafficGeneratorPacketsPerSecond,
 		e.testDuration,
 		e.verbosePrintsEnabled,

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -101,9 +101,7 @@ func (e Executor) Execute(ctx context.Context, vmiUnderTestName, trafficGenVMINa
 	}
 
 	testpmdConsole := testpmd.NewTestpmdConsole(
-		e.vmiSerialClient,
-		e.namespace,
-		vmiUnderTestName,
+		vmiUnderTestConsoleExpecter,
 		e.vmiUnderTestEastNICPCIAddress,
 		e.trafficGenEastMACAddress,
 		e.vmiUnderTestWestNICPCIAddress,

--- a/pkg/internal/checkup/executor/testpmd/console.go
+++ b/pkg/internal/checkup/executor/testpmd/console.go
@@ -93,13 +93,13 @@ func (t TestpmdConsole) Run() error {
 
 	testpmdCmd := buildTestpmdCmd(t.vmiEastNICPCIAddress, t.vmiWestNICPCIAddress, t.vmiEastEthPeerMACAddress, t.vmiWestEthPeerMACAddress)
 
-	resp, err := console.SafeExpectBatchWithResponse(t.vmiSerialClient, t.namespace, t.vmiName,
-		[]expect.Batcher{
-			&expect.BSnd{S: testpmdCmd + "\n"},
-			&expect.BExp{R: testpmdPrompt},
-			&expect.BSnd{S: "start" + "\n"},
-			&expect.BExp{R: testpmdPrompt},
-		},
+	consoleExpecter := console.NewExpecter(t.vmiSerialClient, t.namespace, t.vmiName)
+	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+		&expect.BSnd{S: testpmdCmd + "\n"},
+		&expect.BExp{R: testpmdPrompt},
+		&expect.BSnd{S: "start" + "\n"},
+		&expect.BExp{R: testpmdPrompt},
+	},
 		batchTimeout,
 	)
 
@@ -117,11 +117,11 @@ func (t TestpmdConsole) ClearStats() error {
 
 	const testpmdCmd = "clear fwd stats all"
 
-	_, err := console.SafeExpectBatchWithResponse(t.vmiSerialClient, t.namespace, t.vmiName,
-		[]expect.Batcher{
-			&expect.BSnd{S: testpmdCmd + "\n"},
-			&expect.BExp{R: testpmdPrompt},
-		},
+	consoleExpecter := console.NewExpecter(t.vmiSerialClient, t.namespace, t.vmiName)
+	_, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+		&expect.BSnd{S: testpmdCmd + "\n"},
+		&expect.BExp{R: testpmdPrompt},
+	},
 		batchTimeout,
 	)
 
@@ -139,11 +139,11 @@ func (t TestpmdConsole) GetStats() ([StatsArraySize]PortStats, error) {
 
 	testpmdCmd := "show fwd stats all"
 
-	resp, err := console.SafeExpectBatchWithResponse(t.vmiSerialClient, t.namespace, t.vmiName,
-		[]expect.Batcher{
-			&expect.BSnd{S: testpmdCmd + "\n"},
-			&expect.BExp{R: testpmdPromt},
-		},
+	consoleExpecter := console.NewExpecter(t.vmiSerialClient, t.namespace, t.vmiName)
+	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+		&expect.BSnd{S: testpmdCmd + "\n"},
+		&expect.BExp{R: testpmdPromt},
+	},
 		batchTimeout,
 	)
 

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -85,11 +85,11 @@ func NewClient(vmiSerialClient vmiSerialConsoleClient,
 
 func (c Client) StartServer() error {
 	command := "systemctl start " + SystemdUnitFileName
-	_, err := console.SafeExpectBatchWithResponse(c.vmiSerialClient, c.namespace, c.vmiName,
-		[]expect.Batcher{
-			&expect.BSnd{S: command + "\n"},
-			&expect.BExp{R: shellPrompt},
-		},
+	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
+	_, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+		&expect.BSnd{S: command + "\n"},
+		&expect.BExp{R: shellPrompt},
+	},
 		batchTimeout,
 	)
 	return err
@@ -206,11 +206,11 @@ func (c Client) printTrexServiceFailLogs() error {
 
 func (c Client) getTrexServiceStatus() (string, error) {
 	command := fmt.Sprintf("systemctl status %s | cat", SystemdUnitFileName)
-	resp, err := console.SafeExpectBatchWithResponse(c.vmiSerialClient, c.namespace, c.vmiName,
-		[]expect.Batcher{
-			&expect.BSnd{S: command + "\n"},
-			&expect.BExp{R: shellPrompt},
-		},
+	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
+	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+		&expect.BSnd{S: command + "\n"},
+		&expect.BExp{R: shellPrompt},
+	},
 		batchTimeout,
 	)
 	return resp[0].Output, err
@@ -218,11 +218,11 @@ func (c Client) getTrexServiceStatus() (string, error) {
 
 func (c Client) getTrexServiceJournalctl() (string, error) {
 	command := fmt.Sprintf("journalctl | grep %s", SystemdUnitFileName)
-	resp, err := console.SafeExpectBatchWithResponse(c.vmiSerialClient, c.namespace, c.vmiName,
-		[]expect.Batcher{
-			&expect.BSnd{S: command + "\n"},
-			&expect.BExp{R: shellPrompt},
-		},
+	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
+	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+		&expect.BSnd{S: command + "\n"},
+		&expect.BExp{R: shellPrompt},
+	},
 		batchTimeout,
 	)
 	return resp[0].Output, err
@@ -240,11 +240,11 @@ func (c Client) getStartTrafficCmd(port PortIdx) string {
 
 func (c Client) runTrexConsoleCmd(command string) (string, error) {
 	shellCommand := fmt.Sprintf("cd %s && echo %q | ./trex-console -q", BinDirectory, command)
-	resp, err := console.SafeExpectBatchWithResponse(c.vmiSerialClient, c.namespace, c.vmiName,
-		[]expect.Batcher{
-			&expect.BSnd{S: shellCommand + "\n"},
-			&expect.BExp{R: shellPrompt},
-		},
+	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
+	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+		&expect.BSnd{S: shellCommand + "\n"},
+		&expect.BExp{R: shellPrompt},
+	},
 		batchTimeout,
 	)
 
@@ -259,11 +259,11 @@ func (c Client) runTrexConsoleCmdWithJSONResponse(command, requestKey string) (s
 	trexConsoleCommand := verboseOn + command
 	shellCommand := fmt.Sprintf("cd %s && echo %q | ./trex-console -q", BinDirectory, trexConsoleCommand)
 
-	resp, err := console.SafeExpectBatchWithResponse(c.vmiSerialClient, c.namespace, c.vmiName,
-		[]expect.Batcher{
-			&expect.BSnd{S: shellCommand + "\n"},
-			&expect.BExp{R: shellPrompt},
-		},
+	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
+	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+		&expect.BSnd{S: shellCommand + "\n"},
+		&expect.BExp{R: shellPrompt},
+	},
 		batchTimeout,
 	)
 

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -32,20 +32,14 @@ import (
 	expect "github.com/google/goexpect"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"kubevirt.io/client-go/kubecli"
-
-	"github.com/kiagnose/kubevirt-dpdk-checkup/pkg/internal/checkup/executor/console"
 )
 
-type vmiSerialConsoleClient interface {
-	VMISerialConsole(namespace, name string, timeout time.Duration) (kubecli.StreamInterface, error)
+type consoleExpecter interface {
+	SafeExpectBatchWithResponse(expected []expect.Batcher, timeout time.Duration) ([]expect.BatchRes, error)
 }
 
 type Client struct {
-	vmiSerialClient                  vmiSerialConsoleClient
-	namespace                        string
-	vmiName                          string
+	consoleExpecter                  consoleExpecter
 	trafficGeneratorPacketsPerSecond string
 	testDuration                     time.Duration
 	verbosePrintsEnabled             bool
@@ -67,16 +61,12 @@ const (
 	batchTimeout = 30 * time.Second
 )
 
-func NewClient(vmiSerialClient vmiSerialConsoleClient,
-	namespace,
-	vmiName,
+func NewClient(trafficGenConsoleExpecter consoleExpecter,
 	trafficGeneratorPacketsPerSecond string,
 	testDuration time.Duration,
 	verbosePrintsEnabled bool) Client {
 	return Client{
-		vmiSerialClient:                  vmiSerialClient,
-		namespace:                        namespace,
-		vmiName:                          vmiName,
+		consoleExpecter:                  trafficGenConsoleExpecter,
 		trafficGeneratorPacketsPerSecond: trafficGeneratorPacketsPerSecond,
 		testDuration:                     testDuration,
 		verbosePrintsEnabled:             verbosePrintsEnabled,
@@ -85,8 +75,7 @@ func NewClient(vmiSerialClient vmiSerialConsoleClient,
 
 func (c Client) StartServer() error {
 	command := "systemctl start " + SystemdUnitFileName
-	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
-	_, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+	_, err := c.consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
 		&expect.BSnd{S: command + "\n"},
 		&expect.BExp{R: shellPrompt},
 	},
@@ -206,8 +195,7 @@ func (c Client) printTrexServiceFailLogs() error {
 
 func (c Client) getTrexServiceStatus() (string, error) {
 	command := fmt.Sprintf("systemctl status %s | cat", SystemdUnitFileName)
-	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
-	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+	resp, err := c.consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
 		&expect.BSnd{S: command + "\n"},
 		&expect.BExp{R: shellPrompt},
 	},
@@ -218,8 +206,7 @@ func (c Client) getTrexServiceStatus() (string, error) {
 
 func (c Client) getTrexServiceJournalctl() (string, error) {
 	command := fmt.Sprintf("journalctl | grep %s", SystemdUnitFileName)
-	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
-	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+	resp, err := c.consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
 		&expect.BSnd{S: command + "\n"},
 		&expect.BExp{R: shellPrompt},
 	},
@@ -240,8 +227,7 @@ func (c Client) getStartTrafficCmd(port PortIdx) string {
 
 func (c Client) runTrexConsoleCmd(command string) (string, error) {
 	shellCommand := fmt.Sprintf("cd %s && echo %q | ./trex-console -q", BinDirectory, command)
-	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
-	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+	resp, err := c.consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
 		&expect.BSnd{S: shellCommand + "\n"},
 		&expect.BExp{R: shellPrompt},
 	},
@@ -259,8 +245,7 @@ func (c Client) runTrexConsoleCmdWithJSONResponse(command, requestKey string) (s
 	trexConsoleCommand := verboseOn + command
 	shellCommand := fmt.Sprintf("cd %s && echo %q | ./trex-console -q", BinDirectory, trexConsoleCommand)
 
-	consoleExpecter := console.NewExpecter(c.vmiSerialClient, c.namespace, c.vmiName)
-	resp, err := consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
+	resp, err := c.consoleExpecter.SafeExpectBatchWithResponse([]expect.Batcher{
 		&expect.BSnd{S: shellCommand + "\n"},
 		&expect.BExp{R: shellPrompt},
 	},


### PR DESCRIPTION
This PR is refactoring the console package, in order to be consumed as an object, to be used by other packages like the executor, testpmd and trex packages.