### PR TITLE
vm image builder: Upgrade to CentOS Stream 9

### DIFF
--- a/vms/image-builder/Dockerfile
+++ b/vms/image-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN dnf install -y libguestfs-tools && \
+RUN dnf install -y guestfs-tools && \
     dnf clean all


### PR DESCRIPTION
Currently, we are building VM images using CentOS Stream 8 base image.
CentOS Stream 9 is the latest major version of CentOS Stream. Bump the base image to CentOS Stream 9.

The `libguestfs-tools` package (which contains virt-builder) had been renamed to `guestfs-tools`.

It is important to note that the VM under test and the traffic gen VM will still run on CentOS Stream **8**.