### PR TITLE
Config: Reduce default trafficGenPacketsPerSecond

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ roleRef:
 | spec.param.networkAttachmentDefinitionName | NetworkAttachmentDefinition name of the SR-IOV NICs connected          | True         | Assumed to be in the same namespace                                   |
 | spec.param.trafficGenContainerDiskImage    | Traffic generator's container disk image                               | False        | Defaults to `quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main` |
 | spec.param.trafficGenTargetNodeName        | Node Name on which the traffic generator VM will be scheduled to       | False        | Assumed to be configured to Nodes that allow DPDK traffic             |
-| spec.param.trafficGenPacketsPerSecond      | Amount of packets per second. format: <amount>[/k/m] k-kilo; m-million | False        | Defaults to 14m                                                       |
+| spec.param.trafficGenPacketsPerSecond      | Amount of packets per second. format: <amount>[/k/m] k-kilo; m-million | False        | Defaults to 8m                                                        |
 | spec.param.vmUnderTestContainerDiskImage   | VM under test container disk image                                     | False        | Defaults to `quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main`          |
 | spec.param.vmUnderTestTargetNodeName       | Node Name on which the VM under test will be scheduled to              | False        | Assumed to be configured to Nodes that allow DPDK traffic             |
 | spec.param.testDuration                    | How much time will the traffic generator will run                      | False        | Defaults to 5 Minutes                                                 |

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -44,7 +44,7 @@ const (
 
 const (
 	TrafficGenDefaultContainerDiskImage  = "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main"
-	TrafficGenDefaultPacketsPerSecond    = "14m"
+	TrafficGenDefaultPacketsPerSecond    = "8m"
 	VMUnderTestDefaultContainerDiskImage = "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main"
 	TestDurationDefault                  = 5 * time.Minute
 	PortBandwidthGbpsDefault             = 10


### PR DESCRIPTION
In our tests so far, with the current CI hardware, we haven't been able to pass the eight million pps threshold with zero packet loss.

Set the default value of `trafficGenPacketsPerSecond` to eight million.