### PR TITLE
checkup, executor: Remove DPDK VM phrasing from logs

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -145,12 +145,12 @@ func (c *Checkup) Run(ctx context.Context) error {
 	}
 
 	if c.results.VMUnderTestRxDroppedPackets != 0 || c.results.VMUnderTestTxDroppedPackets != 0 {
-		return fmt.Errorf("detected packets dropped on the DPDK VM's side: RX: %d; TX: %d",
+		return fmt.Errorf("detected packets dropped on the VM-Under-Test's side: RX: %d; TX: %d",
 			c.results.VMUnderTestRxDroppedPackets, c.results.VMUnderTestTxDroppedPackets)
 	}
 
 	if c.results.TrafficGenSentPackets != c.results.VMUnderTestReceivedPackets {
-		return fmt.Errorf("not all generated packets had reached DPDK VM: Sent from traffic generator: %d; Received on DPDK VM: %d",
+		return fmt.Errorf("not all generated packets had reached VM-Under-Test: Sent from traffic generator: %d; Received on VM-Under-Test: %d",
 			c.results.TrafficGenSentPackets, c.results.VMUnderTestReceivedPackets)
 	}
 

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -165,17 +165,19 @@ func calculateStats(trexClient trex.Client, testpmdConsole *testpmd.TestpmdConso
 	results.TrafficGenSentPackets = trafficGeneratorSrcPortStats.Result.Opackets
 	log.Printf("traffic Generator packet sent via port %d: %d", trex.SourcePort, results.TrafficGenSentPackets)
 
-	log.Printf("get testpmd stats in DPDK VMI...")
+	log.Printf("get testpmd stats in VM-Under-Test...")
 	var testPmdStats [testpmd.StatsArraySize]testpmd.PortStats
 	if testPmdStats, err = testpmdConsole.GetStats(); err != nil {
 		return status.Results{}, err
 	}
 	results.VMUnderTestRxDroppedPackets = testPmdStats[testpmd.StatsSummary].RXDropped
 	results.VMUnderTestTxDroppedPackets = testPmdStats[testpmd.StatsSummary].TXDropped
-	log.Printf("DPDK side packets Dropped: Rx: %d; TX: %d", results.VMUnderTestRxDroppedPackets, results.VMUnderTestTxDroppedPackets)
+	log.Printf("VMI-Under-Test's side packets Dropped: Rx: %d; TX: %d",
+		results.VMUnderTestRxDroppedPackets, results.VMUnderTestTxDroppedPackets)
 	results.VMUnderTestReceivedPackets =
 		testPmdStats[testpmd.StatsSummary].RXTotal - testPmdStats[testpmd.StatsPort0].TXPackets - testPmdStats[testpmd.StatsPort1].RXPackets
-	log.Printf("DPDK side test packets received (including dropped, excluding non-related packets): %d", results.VMUnderTestReceivedPackets)
+	log.Printf("VMI-Under-Test's side test packets received (including dropped, excluding non-related packets): %d",
+		results.VMUnderTestReceivedPackets)
 
 	return results, nil
 }


### PR DESCRIPTION
As the VM under test changed it name from DPDK VM, to "VM Under Test", this was not changed in all the logs as well.
Replacing name accordingly.