### PR TITLE
E2E: Conditionally configure containerDisk images

### DIFF
--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -283,19 +283,27 @@ func newRoleBinding(name, serviceAccountName, roleName string) *rbacv1.RoleBindi
 }
 
 func newConfigMap() *corev1.ConfigMap {
+	testConfig := map[string]string{
+		"spec.timeout": "10m",
+		"spec.param.networkAttachmentDefinitionName": networkAttachmentDefinitionName,
+		"spec.param.trafficGenPacketsPerSecond":      "8m",
+		"spec.param.testDuration":                    "1m",
+		"spec.param.verbose":                         "true",
+	}
+
+	if trafficGenContainerDiskImage != "" {
+		testConfig["spec.param.trafficGenContainerDiskImage"] = trafficGenContainerDiskImage
+	}
+
+	if vmUnderTestContainerDiskImage != "" {
+		testConfig["spec.param.vmUnderTestContainerDiskImage"] = vmUnderTestContainerDiskImage
+	}
+
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testConfigMapName,
 		},
-		Data: map[string]string{
-			"spec.timeout": "10m",
-			"spec.param.networkAttachmentDefinitionName": networkAttachmentDefinitionName,
-			"spec.param.trafficGenContainerDiskImage":    trafficGenContainerDiskImage,
-			"spec.param.trafficGenPacketsPerSecond":      "8m",
-			"spec.param.vmUnderTestContainerDiskImage":   vmUnderTestContainerDiskImage,
-			"spec.param.testDuration":                    "1m",
-			"spec.param.verbose":                         "true",
-		},
+		Data: testConfig,
 	}
 }
 


### PR DESCRIPTION
Currently, `TRAFFIC_GEN_CONTAINER_DISK_IMAGE` and `VM_UNDER_TEST_CONTAINER_DISK_IMAGE` environment
variables are optional.

In case the user does not define them, empty strings are passed to the checkup via the user-supplied ConfigMap.

Pass the container disk URLs only in case they are not empty.

~~This PR depends on PR #180, please review only the last commit.~~