### PR TITLE
reporter: Refactor Unit tests

### DIFF
--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -52,22 +52,21 @@ func TestReportShouldSucceed(t *testing.T) {
 
 func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 	const (
-		expectedTrafficGenSentPackets        = 0
-		expectedTrafficGenOutputErrorPackets = 0
-		expectedTrafficGenInputErrorPackets  = 0
-		expectedVMUnderTestReceivedPackets   = 0
-		expectedVMUnderTestRxDroppedPackets  = 0
-		expectedVMUnderTestTxDroppedPackets  = 0
-		expectedVMUnderTestActualNodeName    = "dpdk-node01"
-		expectedTrafficGenActualNodeName     = "dpdk-node02"
-	)
-
-	const (
 		failureReason1 = "some reason"
 		failureReason2 = "some other reason"
 	)
 
 	t.Run("on checkup success", func(t *testing.T) {
+		const (
+			expectedTrafficGenSentPackets        = 0
+			expectedTrafficGenOutputErrorPackets = 0
+			expectedTrafficGenInputErrorPackets  = 0
+			expectedVMUnderTestReceivedPackets   = 0
+			expectedVMUnderTestRxDroppedPackets  = 0
+			expectedVMUnderTestTxDroppedPackets  = 0
+			expectedVMUnderTestActualNodeName    = "dpdk-node01"
+			expectedTrafficGenActualNodeName     = "dpdk-node02"
+		)
 		fakeClient := fake.NewSimpleClientset(newConfigMap())
 		testReporter := reporter.New(fakeClient, testNamespace, testConfigMapName)
 

--- a/pkg/internal/reporter/reporter_test.go
+++ b/pkg/internal/reporter/reporter_test.go
@@ -59,10 +59,10 @@ type checkupFailureCase struct {
 func TestReportShouldSuccessfullyReportResults(t *testing.T) {
 	t.Run("on checkup success", func(t *testing.T) {
 		const (
-			expectedTrafficGenSentPackets        = 0
+			expectedTrafficGenSentPackets        = 100
 			expectedTrafficGenOutputErrorPackets = 0
 			expectedTrafficGenInputErrorPackets  = 0
-			expectedVMUnderTestReceivedPackets   = 0
+			expectedVMUnderTestReceivedPackets   = 100
 			expectedVMUnderTestRxDroppedPackets  = 0
 			expectedVMUnderTestTxDroppedPackets  = 0
 			expectedVMUnderTestActualNodeName    = "dpdk-node01"


### PR DESCRIPTION
The current reporter unit tests are testing against a zero results value. 
As the checkup now does not support zero results as a success case, this unit test requires a change.
Refactor unit tests to make them more readable. 
Add non zero success case and  non zero-fail case.