### PR TITLE
checkup: Fix teardown logic

### DIFF
--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -176,9 +176,12 @@ func TestTeardownShouldFailWhen(t *testing.T) {
 		assert.NoError(t, testCheckup.Setup(context.Background()))
 		assert.NoError(t, testCheckup.Run(context.Background()))
 
-		vmiDeletionFailureErr := errors.New("failed to delete VMI")
-		testClient.vmiDeletionFailure = vmiDeletionFailureErr
-		assert.ErrorIs(t, testCheckup.Teardown(context.Background()), vmiDeletionFailureErr)
+		testCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+
+		const vmiDeletionFailureErrMsg = "failed to delete VMI"
+		testClient.vmiDeletionFailure = errors.New(vmiDeletionFailureErrMsg)
+		assert.ErrorContains(t, testCheckup.Teardown(testCtx), vmiDeletionFailureErrMsg)
 	})
 	t.Run("VMIs were not disposed before timeout expiration", func(t *testing.T) {
 		testClient := newClientStub()

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -174,19 +174,19 @@ func TestTeardownShouldFailWhen(t *testing.T) {
 	}
 
 	const (
-		vmiReadFailureMsg     = "failed to delete VMI"
-		vmiDeletionFailureMsg = "failed to read VMI"
+		vmiDeletionFailureMsg = "failed to delete VMI"
+		vmiReadFailureMsg     = "failed to read VMI"
 	)
 	testCases := []FailTestCase{
 		{
-			description:     "VMI deletion fails",
-			vmiReadFailure:  errors.New(vmiReadFailureMsg),
-			expectedFailure: vmiReadFailureMsg,
-		},
-		{
-			description:        "wait for VMI deletion fails",
+			description:        "VMI deletion fails",
 			vmiDeletionFailure: errors.New(vmiDeletionFailureMsg),
 			expectedFailure:    vmiDeletionFailureMsg,
+		},
+		{
+			description:     "wait for VMI Read fails",
+			vmiReadFailure:  errors.New(vmiReadFailureMsg),
+			expectedFailure: vmiReadFailureMsg,
 		},
 	}
 

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -168,25 +168,18 @@ func TestSetupShouldFail(t *testing.T) {
 func TestTeardownShouldFailWhen(t *testing.T) {
 	type FailTestCase struct {
 		description        string
-		vmiReadFailure     error
 		vmiDeletionFailure error
 		expectedFailure    string
 	}
 
 	const (
 		vmiDeletionFailureMsg = "failed to delete VMI"
-		vmiReadFailureMsg     = "failed to read VMI"
 	)
 	testCases := []FailTestCase{
 		{
 			description:        "VMI deletion fails",
 			vmiDeletionFailure: errors.New(vmiDeletionFailureMsg),
 			expectedFailure:    vmiDeletionFailureMsg,
-		},
-		{
-			description:     "wait for VMI Read fails",
-			vmiReadFailure:  errors.New(vmiReadFailureMsg),
-			expectedFailure: vmiReadFailureMsg,
 		},
 	}
 
@@ -201,7 +194,6 @@ func TestTeardownShouldFailWhen(t *testing.T) {
 			assert.NoError(t, testCheckup.Run(context.Background()))
 
 			testClient.vmiDeletionFailure = testCase.vmiDeletionFailure
-			testClient.vmiReadFailure = testCase.vmiReadFailure
 			assert.ErrorContains(t, testCheckup.Teardown(context.Background()), testCase.expectedFailure)
 		})
 	}


### PR DESCRIPTION
Currently, the teardown logic is as follows:

1. Remove the VMI under test
2. Remove the traffic gen
3. Remove the traffic gen ConfigMap
4. Wait for VMI under test to be removed
5. Wait for the traffic gen to be removed.
In case any of the above steps fails, the entire teardown fails.

Align this logic with the VM latency checkup, in which the errors are accumulated.