### PR TITLE
Makefile: Set the tag of the checukp's base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ORG ?= kiagnose
 CHECKUP_IMAGE_NAME ?= kubevirt-dpdk-checkup
 CHECKUP_IMAGE_TAG ?= latest
 CHECKUP_GIT_TAG ?= $(shell git describe --always --abbrev=8 --tags)
-CHECKUP_BASE_IMAGE_TAG ?= latest
+CHECKUP_BASE_IMAGE_TAG ?= 9.2-717
 VM_IMAGE_BUILDER_IMAGE_NAME := kubevirt-dpdk-checkup-vm-image-builder
 VM_IMAGE_BUILDER_IMAGE_TAG ?= latest
 VIRT_BUILDER_CACHE_DIR := $(CURDIR)/_virt_builder/cache

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ORG ?= kiagnose
 CHECKUP_IMAGE_NAME ?= kubevirt-dpdk-checkup
 CHECKUP_IMAGE_TAG ?= latest
 CHECKUP_GIT_TAG ?= $(shell git describe --always --abbrev=8 --tags)
+CHECKUP_BASE_IMAGE_TAG ?= latest
 VM_IMAGE_BUILDER_IMAGE_NAME := kubevirt-dpdk-checkup-vm-image-builder
 VM_IMAGE_BUILDER_IMAGE_TAG ?= latest
 VIRT_BUILDER_CACHE_DIR := $(CURDIR)/_virt_builder/cache
@@ -15,7 +16,6 @@ GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.20.6
 BIN_DIR = $(CURDIR)/_output/bin
 CRI_BIN ?= $(shell hack/detect_cri.sh)
-CHECKUP_BASE_IMAGE_TAG ?= latest
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
 LINTER_IMAGE_TAG := v1.50.1
 GO_MOD_VERSION=$(shell hack/go-mod-version.sh)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_IMAGE_NAME := docker.io/library/golang
 GO_IMAGE_TAG := 1.20.6
 BIN_DIR = $(CURDIR)/_output/bin
 CRI_BIN ?= $(shell hack/detect_cri.sh)
-CRI_BUILD_BASE_IMAGE_TAG ?= latest
+CHECKUP_BASE_IMAGE_TAG ?= latest
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
 LINTER_IMAGE_TAG := v1.50.1
 GO_MOD_VERSION=$(shell hack/go-mod-version.sh)
@@ -37,7 +37,7 @@ build:
 	           -e GOOS=linux \
 	           -e GOARCH=amd64 \
 	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go build -v -o $(BIN_DIR)/$(CHECKUP_IMAGE_NAME) ./cmd/
-	$(CRI_BIN) build --build-arg BASE_IMAGE_TAG=$(CRI_BUILD_BASE_IMAGE_TAG) . -t $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
+	$(CRI_BIN) build --build-arg BASE_IMAGE_TAG=$(CHECKUP_BASE_IMAGE_TAG) . -t $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: build
 
 push:


### PR DESCRIPTION
Currently, `CRI_BUILD_BASE_IMAGE_TAG` is used to set the tag of the checkup's base image [1].
Rename this variable to `CHECKUP_BASE_IMAGE_TAG` in order to better represent its purpose.

Currently, the value of `CHECKUP_BASE_IMAGE_TAG` is `latest`, which makes the build unpredictable - software versions
might change between builds.

This problem is even worse when building an old version of the checkup.

Set the value of `CHECKUP_BASE_IMAGE_TAG` to the latest ubi9-minimal tag [2].

[1] registry.access.redhat.com/ubi9/ubi-minimal
[2] https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?push_date=1690889472000&architecture=amd64