### PR TITLE
vmi spec: Add isolateEmulatorThread option

### DIFF
--- a/pkg/internal/checkup/vmi/spec.go
+++ b/pkg/internal/checkup/vmi/spec.go
@@ -113,6 +113,7 @@ func WithDedicatedCPU(socketsCount, coresCount, threadsCount uint32) Option {
 			Cores:                 coresCount,
 			Threads:               threadsCount,
 			DedicatedCPUPlacement: true,
+			IsolateEmulatorThread: true,
 		}
 	}
 }


### PR DESCRIPTION
Add the isolateEmulatorThread option[1] for the two VMIs. This will cause the emulator to run on a CPU of its own, instead of running on the same physical CPUs as the VMs' vCPUs.

In theory, this should help reduce the packet losses.

Currently, there is a bug[2] in KubeVirt that prevents the creation of VMs with an even CPU count and the isolateEmulatorThread option enabled, on nodes with hyperthreading[3] enabled.
The above bug causes the checkup setup phase to fail.

A workaround is to run the checkup on nodes with hyperthreading disabled.

[1] https://kubevirt.io/user-guide/virtual_machines/dedicated_cpu_resources/#requesting-dedicated-cpu-for-qemu-emulator
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2228103
[3] https://en.wikipedia.org/wiki/Hyper-threading