### PR TITLE
Remove isolcpus karg

### DIFF
--- a/docs/Configuring_openshift_virtualization_vm_for_dpdk.md
+++ b/docs/Configuring_openshift_virtualization_vm_for_dpdk.md
@@ -232,6 +232,12 @@ spec:
 
 Once the VM is deployed and running, there are configurations that need to be set once on the guest. The changes are explained on each subchapter with appropriate snippets. In the end, an example guest configuration summary script is offered.
 
+### Linux grub cmdLine on guest
+The hugepages are specified on the grub cmdLine:
+```bash
+grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=8"
+```
+
 ### CPU isolation on guest
 
 If we continue with the example from previous chapters, 5 hyper-threads translate to 10 CPUs on the guest:
@@ -253,11 +259,6 @@ The expected result should look like this:
 ```
 
 That leaves CPUS `2-9` to be configured as isolated.
-Linux grub cmdLine on guest
-The hugepages and isolated CPU are specified on the grub cmdLine:
-```bash
-grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=8 isolcpus=2-9"
-```
 
 ### CPU partitioning on guest
 

--- a/vms/traffic-gen/scripts/customize-vm
+++ b/vms/traffic-gen/scripts/customize-vm
@@ -22,7 +22,7 @@ set -e
 systemctl disable NetworkManager-wait-online
 systemctl disable sshd
 
-grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1 isolcpus=2-7"
+grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1"
 
 echo  isolated_cores=2-7 > /etc/tuned/cpu-partitioning-variables.conf
 tuned-adm profile cpu-partitioning

--- a/vms/vm-under-test/scripts/customize-vm
+++ b/vms/vm-under-test/scripts/customize-vm
@@ -20,7 +20,7 @@
 systemctl disable NetworkManager-wait-online
 systemctl disable sshd
 
-grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1 isolcpus=2-7"
+grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1"
 
 echo  isolated_cores=2-7 > /etc/tuned/cpu-partitioning-variables.conf
 tuned-adm profile cpu-partitioning


### PR DESCRIPTION
This PR is removing the `isolcpus` kernel argument from the VMs image and also from the documentation, as it is no longer needed on RHEL 8,9 [0].

[0] https://access.redhat.com/articles/6126451