### PR TITLE
trex: Refactor App configuration

### DIFF
--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -47,6 +47,8 @@ type Config struct {
 	trafficGeneratorWestMacAddress string
 	DPDKEastMacAddress             string
 	DPDKWestMacAddress             string
+	rxDesc                         string
+	txDesc                         string
 }
 
 func NewConfig(cfg config.Config) Config {
@@ -55,6 +57,8 @@ func NewConfig(cfg config.Config) Config {
 		latencyCPU       = "3"
 		trafficCPUs      = "4,5,6,7"
 		numOfTrafficCPUs = "4"
+		rxDesc           = "4096"
+		txDesc           = "4096"
 	)
 	return Config{
 		masterCPU:                      masterCPU,
@@ -66,6 +70,8 @@ func NewConfig(cfg config.Config) Config {
 		trafficGeneratorWestMacAddress: cfg.TrafficGenWestMacAddress.String(),
 		DPDKEastMacAddress:             cfg.VMUnderTestEastMacAddress.String(),
 		DPDKWestMacAddress:             cfg.VMUnderTestWestMacAddress.String(),
+		rxDesc:                         rxDesc,
+		txDesc:                         txDesc,
 	}
 }
 
@@ -75,6 +81,8 @@ func (c Config) GenerateCfgFile() string {
   interfaces:
     - %q
     - %q
+  rx_desc: %s
+  tx_desc: %s
   port_bandwidth_gb: %s
   port_info:
     - ip: 10.10.10.2
@@ -91,6 +99,8 @@ func (c Config) GenerateCfgFile() string {
 	return fmt.Sprintf(cfgTemplate,
 		config.VMIEastNICPCIAddress,
 		config.VMIWestNICPCIAddress,
+		c.rxDesc,
+		c.txDesc,
 		c.portBandwidthGB,
 		c.masterCPU,
 		c.latencyCPU,

--- a/pkg/internal/checkup/trex/configfiles.go
+++ b/pkg/internal/checkup/trex/configfiles.go
@@ -51,10 +51,10 @@ type Config struct {
 
 func NewConfig(cfg config.Config) Config {
 	const (
-		masterCPU        = "0"
-		latencyCPU       = "1"
-		trafficCPUs      = "2,3,4,5,6,7"
-		numOfTrafficCPUs = "6"
+		masterCPU        = "2"
+		latencyCPU       = "3"
+		trafficCPUs      = "4,5,6,7"
+		numOfTrafficCPUs = "4"
 	)
 	return Config{
 		masterCPU:                      masterCPU,

--- a/pkg/internal/checkup/trex/configfiles_test.go
+++ b/pkg/internal/checkup/trex/configfiles_test.go
@@ -47,11 +47,11 @@ func TestGetTrexCfgFile(t *testing.T) {
     - ip: 10.10.20.2
       default_gw: 10.10.20.1
   platform:
-    master_thread_id: 0
-    latency_thread_id: 1
+    master_thread_id: 2
+    latency_thread_id: 3
     dual_if:
       - socket: 0
-        threads: [2,3,4,5,6,7]
+        threads: [4,5,6,7]
 `
 	assert.Equal(t, expectedCfgFile, cfgFile)
 }
@@ -95,7 +95,7 @@ class STLS1(object):
     def get_streams (self, direction = 0, **kwargs):
         # create multiple streams, one stream per core generating traffic...
         s = []
-        for i in range(6):
+        for i in range(4):
             s.append(self.create_stream(direction = direction))
         return s
 
@@ -127,7 +127,7 @@ func TestExecutionScript(t *testing.T) {
 	actualExecutionScript := trexConfig.GenerateExecutionScript()
 
 	expextedExecutionScript := `#!/usr/bin/env bash
-./t-rex-64 --no-ofed-check --no-scapy-server --no-hw-flow-stat -i -c 6 --iom 0
+./t-rex-64 --no-ofed-check --no-scapy-server --no-hw-flow-stat -i -c 4 --iom 0
 `
 
 	assert.Equal(t, expextedExecutionScript, actualExecutionScript)

--- a/pkg/internal/checkup/trex/configfiles_test.go
+++ b/pkg/internal/checkup/trex/configfiles_test.go
@@ -40,6 +40,8 @@ func TestGetTrexCfgFile(t *testing.T) {
   interfaces:
     - "0000:06:00.0"
     - "0000:07:00.0"
+  rx_desc: 4096
+  tx_desc: 4096
   port_bandwidth_gb: 40
   port_info:
     - ip: 10.10.10.2


### PR DESCRIPTION
When configuring the cores that will run the traffic one needs to think of the current topology.


Currently the traffic-gen-vmi guest is using 8 CPUs: 0-7. Hence the SMT siblings are set by kubevirt to be 0-1,2-3,4-5,6-7. 0-1 are set to be reserved to the OS on the grub linuxcmd [0]. 2-3 should run the trex master and latency threads (running non DPDK processes)
thus - 4,5,6,7 should be assigned to the forwarding CPUs (four in total).

This commit is changing these parameters in the trex server cmdline[1]:
* -c: the number is not changed but now represents the number of hw threads to use per interface pair (including master and latency which are used internally it is still six)

It is changing the trex_cfg.yaml file:
* update CPU mapping to use the appropriate vCPUs

[0]
https://github.com/kiagnose/kubevirt-dpdk-checkup/blob/e0deb7ead901ca189bba80ca139c6f39949b5d18/vms/traffic-gen/scripts/customize-vm#L27 
[1] https://trex-tgn.cisco.com/trex/doc/trex_manual.html#cml-line