### PR TITLE
Makefile: Disable buildvcs on go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build:
 	           --workdir $(CURDIR) \
 	           -e GOOS=linux \
 	           -e GOARCH=amd64 \
-	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go build -v -o $(BIN_DIR)/$(CHECKUP_IMAGE_NAME) ./cmd/
+	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go build -buildvcs=false -v -o $(BIN_DIR)/$(CHECKUP_IMAGE_NAME) ./cmd/
 	$(CRI_BIN) build --build-arg BASE_IMAGE_TAG=$(CHECKUP_BASE_IMAGE_TAG) . -t $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: build
 


### PR DESCRIPTION
Adding this flag removes a build error.

Fixes https://github.com/kiagnose/kubevirt-dpdk-checkup/issues/200