### PR TITLE
checkup: Increase Setup timeout

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -86,7 +86,7 @@ func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config
 }
 
 func (c *Checkup) Setup(ctx context.Context) (setupErr error) {
-	const setupTimeout = 10 * time.Minute
+	const setupTimeout = 15 * time.Minute
 	setupCtx, cancel := context.WithTimeout(ctx, setupTimeout)
 	defer cancel()
 


### PR DESCRIPTION
The checkup sometimes fails on setup timeout, although nothing seems to be wrong.
Increasing the timeout to 15m.