### PR TITLE
Executer/console: Refactor logs

### DIFF
--- a/pkg/internal/checkup/executor/console/console.go
+++ b/pkg/internal/checkup/executor/console/console.go
@@ -80,7 +80,7 @@ func (e Expecter) spawnConsole(timeout time.Duration) (*expect.GExpect, error) {
 		})
 	}()
 
-	e.opts = append(e.opts, expect.SendTimeout(timeout), expect.Verbose(true))
+	e.opts = append(e.opts, expect.SendTimeout(timeout), expect.Verbose(false))
 	genExpect, _, err := expect.SpawnGeneric(&expect.GenOptions{
 		In:  vmiWriter,
 		Out: expecterReader,

--- a/pkg/internal/checkup/executor/executor.go
+++ b/pkg/internal/checkup/executor/executor.go
@@ -183,7 +183,7 @@ func calculateStats(trexClient trex.Client, testpmdConsole *testpmd.TestpmdConso
 func (e Executor) monitorDropRates(ctx context.Context, trexClient trex.Client) (float64, error) {
 	const interval = 10 * time.Second
 
-	log.Printf("Monitoring traffic generator side drop rates every %ss during the test duration...", interval)
+	log.Printf("Monitoring traffic generator side drop rates every %s during the test duration...", interval)
 	maxDropRateBps := float64(0)
 
 	ctxWithNewDeadline, cancel := context.WithTimeout(ctx, e.testDuration)

--- a/pkg/internal/checkup/executor/testpmd/console.go
+++ b/pkg/internal/checkup/executor/testpmd/console.go
@@ -96,7 +96,10 @@ func (t TestpmdConsole) Run() error {
 		return err
 	}
 
-	log.Printf("%v", resp)
+	if t.verbosePrintsEnabled {
+		log.Printf("testpmd run:\n%s", resp[0].Output)
+		log.Printf("testpmd start:\n%s", resp[1].Output)
+	}
 
 	return nil
 }
@@ -139,7 +142,7 @@ func (t TestpmdConsole) GetStats() ([StatsArraySize]PortStats, error) {
 	}
 
 	if t.verbosePrintsEnabled {
-		log.Printf("testpmd stats: %v", resp)
+		log.Printf("testpmd stats:\n%s", resp[0].Output)
 	}
 
 	return parseTestpmdStats(resp[0].Output)

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -133,7 +133,7 @@ func (c Client) GetGlobalStats() (GlobalStats, error) {
 	}
 
 	if c.verbosePrintsEnabled {
-		log.Printf("GetGlobalStats JSON: %s", globalStatsJSONString)
+		log.Printf("GetGlobalStats JSON Response:\n%s", globalStatsJSONString)
 	}
 
 	var gs GlobalStats
@@ -154,7 +154,7 @@ func (c Client) GetPortStats(port PortIdx) (PortStats, error) {
 	}
 
 	if c.verbosePrintsEnabled {
-		log.Printf("GetPortStats JSON: %s", portStatsJSONString)
+		log.Printf("GetPortStats JSON Response:\n%s", portStatsJSONString)
 	}
 
 	var ps PortStats
@@ -168,6 +168,9 @@ func (c Client) GetPortStats(port PortIdx) (PortStats, error) {
 func (c Client) isServerRunning() bool {
 	const helpSubstring = "Console Commands"
 	resp, err := c.runTrexConsoleCmd("help")
+	if c.verbosePrintsEnabled {
+		log.Printf("trex-console help resp:\n%s", resp)
+	}
 	if err != nil || !strings.Contains(resp, helpSubstring) {
 		return false
 	}

--- a/pkg/internal/checkup/trex/client.go
+++ b/pkg/internal/checkup/trex/client.go
@@ -256,7 +256,13 @@ func (c Client) runTrexConsoleCmdWithJSONResponse(command, requestKey string) (s
 		return "", err
 	}
 
-	return extractJSONString(cleanStdout(resp[0].Output), requestKey)
+	stdout := cleanStdout(resp[0].Output)
+	jsonResponse, err := extractJSONString(stdout, requestKey)
+	if err != nil {
+		log.Printf("failed to extract JSON Response of %q in input: \n%q", requestKey, stdout)
+		return "", fmt.Errorf("failed to extract JSON Response of %q: %w. See logs for more information", requestKey, err)
+	}
+	return jsonResponse, nil
 }
 
 func cleanStdout(rawStdout string) string {


### PR DESCRIPTION
This PR is refactoring the logs that are used on the trex and testpmd clients. 
These logs are logging the input/output of the serial console.
In order to make the DPDK-checkup job logs more readable:
 - Removing duplicates logs
 - Adding more information when needed
 