### PR TITLE
test/e2e: Increase test timeout

### DIFF
--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -42,7 +42,7 @@ const (
 	testConfigMapName                   = "dpdk-checkup-config"
 	testCheckupJobName                  = "dpdk-checkup"
 
-	testTimeout = 10 * time.Minute
+	testTimeout = time.Hour
 	jobGrace    = 5 * time.Minute
 	jobTimeout  = testTimeout + jobGrace
 )


### PR DESCRIPTION
It takes the checkup ~ten minutes to reach the Run phase on the dev cluster, so it makes no sense that the e2e timeout is ten minutes. Increasing to one hour.