### PR TITLE
E2E: Align output error messages

### DIFF
--- a/tests/checkup_test.go
+++ b/tests/checkup_test.go
@@ -108,9 +108,9 @@ var _ = Describe("Execute the checkup Job", func() {
 		Expect(configMap.Data["status.succeeded"]).To(Equal("true"), fmt.Sprintf("should succeed %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.failureReason"]).To(BeEmpty(), fmt.Sprintf("should be empty %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.result.vmUnderTestActualNodeName"]).ToNot(BeEmpty(),
-			fmt.Sprintf("DPDKVMNode should not be empty %+v", prettifyData(configMap.Data)))
+			fmt.Sprintf("vmUnderTestActualNodeName should not be empty %+v", prettifyData(configMap.Data)))
 		Expect(configMap.Data["status.result.trafficGenActualNodeName"]).ToNot(BeEmpty(),
-			fmt.Sprintf("trafficGeneratorNode should not be empty %+v", prettifyData(configMap.Data)))
+			fmt.Sprintf("trafficGenActualNodeName should not be empty %+v", prettifyData(configMap.Data)))
 	})
 })
 


### PR DESCRIPTION
In PR #169, the names of the output fields were changed.

Align the error messages in case the assertions fail.