### PR TITLE
CPU spec: Add NUMA.GuestMappingPassthrough

### DIFF
--- a/pkg/internal/checkup/vmi/spec.go
+++ b/pkg/internal/checkup/vmi/spec.go
@@ -114,6 +114,9 @@ func WithDedicatedCPU(socketsCount, coresCount, threadsCount uint32) Option {
 			Threads:               threadsCount,
 			DedicatedCPUPlacement: true,
 			IsolateEmulatorThread: true,
+			NUMA: &kvcorev1.NUMA{
+				GuestMappingPassthrough: &kvcorev1.NUMAGuestMappingPassthrough{},
+			},
 		}
 	}
 }


### PR DESCRIPTION
This option makes sure that all the CPUs will be from the same NUMA (in KubeVirt's level).

[1] https://kubevirt.io/user-guide/virtual_machines/numa/#guestmappingpassthrough
[2] https://access.redhat.com/solutions/7007632