### PR TITLE
vm-customize: Automatically mount hugepages

### DIFF
--- a/vms/traffic-gen/scripts/customize-vm
+++ b/vms/traffic-gen/scripts/customize-vm
@@ -46,6 +46,9 @@ install_trex() {
 
 # Setup hugepages in cmdline
 setup_hugepages() {
+  mkdir -p /mnt/huge
+  echo "hugetlbfs /mnt/huge hugetlbfs defaults,pagesize=1GB 0 0" >> /etc/fstab
+
   grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1"
 }
 
@@ -108,9 +111,6 @@ checkup_tuned_adm_set_marker_full_path=$1
 
 driverctl set-override 0000:06:00.0 vfio-pci
 driverctl set-override 0000:07:00.0 vfio-pci
-
-mkdir -p /mnt/huge
-mount /mnt/huge --source nodev -t hugetlbfs -o pagesize=1GB
 
 if [ ! -f "$checkup_tuned_adm_set_marker_full_path" ]; then
   echo "isolated_cores=2-7" > /etc/tuned/cpu-partitioning-variables.conf

--- a/vms/vm-under-test/scripts/customize-vm
+++ b/vms/vm-under-test/scripts/customize-vm
@@ -29,6 +29,9 @@ disable_services() {
 
 # Setup hugepages in cmdline
 setup_hugepages() {
+  mkdir -p /mnt/huge
+  echo "hugetlbfs /mnt/huge hugetlbfs defaults,pagesize=1GB 0 0" >> /etc/fstab
+
   grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1"
 }
 
@@ -91,9 +94,6 @@ checkup_tuned_adm_set_marker_full_path=$1
 
 driverctl set-override 0000:06:00.0 vfio-pci
 driverctl set-override 0000:07:00.0 vfio-pci
-
-mkdir -p /mnt/huge
-mount /mnt/huge --source nodev -t hugetlbfs -o pagesize=1GB
 
 if [ ! -f "$checkup_tuned_adm_set_marker_full_path" ]; then
   echo "isolated_cores=2-7" > /etc/tuned/cpu-partitioning-variables.conf


### PR DESCRIPTION
Currently, the mounting of hugepages is performed by the `/usr/bin/dpdk-checkup-boot.sh` script which is executed on every boot.

Move it to the VM configuration phase, so it would be done automatically by the operating system.