### PR TITLE
checkup: Introduce vmi under test configmap

### DIFF
--- a/pkg/internal/checkup/checkup.go
+++ b/pkg/internal/checkup/checkup.go
@@ -81,7 +81,7 @@ func New(client kubeVirtVMIClient, namespace string, checkupConfig config.Config
 		client:                client,
 		namespace:             namespace,
 		params:                checkupConfig,
-		vmiUnderTest:          newVMIUnderTest(vmiUnderTestName(randomSuffix), checkupConfig),
+		vmiUnderTest:          newVMIUnderTest(vmiUnderTestName(randomSuffix), checkupConfig, vmiUnderTestCMName),
 		vmiUnderTestConfigMap: newVMIUnderTestConfigMap(vmiUnderTestCMName, checkupConfig),
 		trafficGen:            newTrafficGen(trafficGenName(randomSuffix), checkupConfig, trafficGenCMName),
 		trafficGenConfigMap:   newTrafficGenConfigMap(trafficGenCMName, checkupConfig),

--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -200,7 +200,7 @@ func TestTeardownShouldFailWhen(t *testing.T) {
 	})
 }
 
-func TestTrafficGenCMTeardownFailure(t *testing.T) {
+func TestVMConfigMapTeardownFailure(t *testing.T) {
 	testClient := newClientStub()
 	testConfig := newTestConfig()
 


### PR DESCRIPTION
This PR introduces a new configmap to the checkup, that will be consumed by the VMI-under-test VMI.
In future PRs this configmap will be used to insert scripts to the guest.
