### PR TITLE
checkup: Add guest agent ping wait

### DIFF
--- a/pkg/internal/checkup/checkup_test.go
+++ b/pkg/internal/checkup/checkup_test.go
@@ -417,10 +417,11 @@ func (cs *clientStub) GetVirtualMachineInstance(_ context.Context, namespace, na
 		return nil, k8serrors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstances"}, name)
 	}
 
-	vmi.Status.Conditions = append(vmi.Status.Conditions, kvcorev1.VirtualMachineInstanceCondition{
-		Type:   kvcorev1.VirtualMachineInstanceAgentConnected,
-		Status: k8scorev1.ConditionTrue,
-	})
+	vmi.Status.Conditions = append(vmi.Status.Conditions,
+		kvcorev1.VirtualMachineInstanceCondition{
+			Type:   kvcorev1.VirtualMachineInstanceReady,
+			Status: k8scorev1.ConditionTrue,
+		})
 
 	return vmi, nil
 }

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -132,7 +132,7 @@ func generateBootScript() string {
 	sb := strings.Builder{}
 
 	sb.WriteString("#!/bin/bash\n")
-	sb.WriteString("set -e\n")
+	sb.WriteString("set -x\n")
 	sb.WriteString("\n")
 	sb.WriteString("checkup_tuned_adm_set_marker_full_path=" + config.BootScriptTunedAdmSetMarkerFileFullPath + "\n")
 	sb.WriteString("\n")

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -141,6 +141,7 @@ func generateBootScript() string {
 	sb.WriteString("  tuned-adm profile cpu-partitioning\n\n")
 	sb.WriteString("  touch $checkup_tuned_adm_set_marker_full_path\n")
 	sb.WriteString("  reboot\n")
+	sb.WriteString("  exit 0\n")
 	sb.WriteString("fi\n")
 	sb.WriteString("\n")
 	sb.WriteString("driverctl set-override " + config.VMIEastNICPCIAddress + " vfio-pci\n")

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -69,6 +69,7 @@ func newVMIUnderTest(name string, checkupConfig config.Config, configMapName str
 		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(vmiUnderTestBootCommands(configDiskSerial))),
 		vmi.WithConfigMapVolume(configVolumeName, configMapName),
 		vmi.WithConfigMapDisk(configVolumeName, configDiskSerial),
+		vmi.WithReadinessFileProbe(config.BootScriptReadinessMarkerFileFullPath),
 	)
 
 	return vmi.New(name, optionsToApply...)
@@ -88,6 +89,7 @@ func newTrafficGen(name string, checkupConfig config.Config, configMapName strin
 		vmi.WithCloudInitNoCloudVolume(cloudInitDiskName, CloudInit(trafficGenBootCommands(configDiskSerial))),
 		vmi.WithConfigMapVolume(configVolumeName, configMapName),
 		vmi.WithConfigMapDisk(configVolumeName, configDiskSerial),
+		vmi.WithReadinessFileProbe(config.BootScriptReadinessMarkerFileFullPath),
 	)
 
 	return vmi.New(name, optionsToApply...)

--- a/pkg/internal/checkup/vmi.go
+++ b/pkg/internal/checkup/vmi.go
@@ -146,6 +146,8 @@ func generateBootScript() string {
 	sb.WriteString("\n")
 	sb.WriteString("driverctl set-override " + config.VMIEastNICPCIAddress + " vfio-pci\n")
 	sb.WriteString("driverctl set-override " + config.VMIWestNICPCIAddress + " vfio-pci\n")
+	sb.WriteString("touch " + config.BootScriptReadinessMarkerFileFullPath + "\n")
+	sb.WriteString("chcon -t virt_qemu_ga_exec_t " + config.BootScriptReadinessMarkerFileFullPath + "\n")
 
 	return sb.String()
 }

--- a/pkg/internal/checkup/vmi/spec.go
+++ b/pkg/internal/checkup/vmi/spec.go
@@ -262,6 +262,23 @@ func WithAffinity(affinity *corev1.Affinity) Option {
 	}
 }
 
+func WithReadinessFileProbe(fileName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		var readinessProbeCommand = []string{"cat", fileName}
+		vmi.Spec.ReadinessProbe = &kvcorev1.Probe{
+			Handler: kvcorev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: readinessProbeCommand,
+				},
+			},
+			FailureThreshold:    30,
+			InitialDelaySeconds: 90,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      10,
+		}
+	}
+}
+
 func Pointer[T any](v T) *T {
 	return &v
 }

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -65,6 +65,7 @@ const (
 	BootScriptName                          = "dpdk-checkup-boot.sh"
 	BootScriptBinDirectory                  = "/usr/bin/"
 	BootScriptTunedAdmSetMarkerFileFullPath = "/var/dpdk-checkup-tuned-adm-set-marker"
+	BootScriptReadinessMarkerFileFullPath   = "/tmp/dpdk-checkup-ready-marker"
 )
 
 var (

--- a/vms/traffic-gen/scripts/customize-vm
+++ b/vms/traffic-gen/scripts/customize-vm
@@ -40,6 +40,12 @@ set_unsafe_no_io_mmu_mode() {
   echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf
 }
 
+# Enable guest-exec on the qemu-guest-agent configuration
+enable_guest_exec() {
+  sed -i '/^BLACKLIST_RPC=/ { s/guest-exec-status//; s/guest-exec//g }' /etc/sysconfig/qemu-ga
+  sed -i '/^BLACKLIST_RPC=/ { s/,\+/,/g; s/^,\|,$//g }' /etc/sysconfig/qemu-ga
+}
+
 # Install trex package
 install_trex() {
   local TREX_URL=https://trex-tgn.cisco.com/trex/release
@@ -60,4 +66,5 @@ install_trex() {
 disable_services
 setup_hugepages
 set_unsafe_no_io_mmu_mode
+enable_guest_exec
 install_trex

--- a/vms/vm-under-test/scripts/customize-vm
+++ b/vms/vm-under-test/scripts/customize-vm
@@ -40,6 +40,13 @@ set_unsafe_no_io_mmu_mode() {
   echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf
 }
 
+# Enable guest-exec on the qemu-guest-agent configuration
+enable_guest_exec() {
+  sed -i '/^BLACKLIST_RPC=/ { s/guest-exec-status//; s/guest-exec//g }' /etc/sysconfig/qemu-ga
+  sed -i '/^BLACKLIST_RPC=/ { s/,\+/,/g; s/^,\|,$//g }' /etc/sysconfig/qemu-ga
+}
+
 disable_services
 setup_hugepages
 set_unsafe_no_io_mmu_mode
+enable_guest_exec


### PR DESCRIPTION
This PR introduces a new algorithm to make sure that the checkups start only after the vmi properly configured for DPDK.
Instead of waiting for the VMI guest-agent condition to be true, introducing a guest-agent-ping probe that will poll for the marker file signaling that the VMI is ready.

~~It relies on #220, first 4 commits do not belong to this PR~~