### PR TITLE
Traffic-gen, customize-vm: Align with VM-under-test

### DIFF
--- a/vms/traffic-gen/scripts/customize-vm
+++ b/vms/traffic-gen/scripts/customize-vm
@@ -27,6 +27,19 @@ disable_services() {
   done
 }
 
+# Setup hugepages in cmdline
+setup_hugepages() {
+  mkdir -p /mnt/huge
+  echo "hugetlbfs /mnt/huge hugetlbfs defaults,pagesize=1GB 0 0" >> /etc/fstab
+
+  grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1"
+}
+
+# Enable unsafe noiommu mode
+set_unsafe_no_io_mmu_mode() {
+  echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf
+}
+
 # Install trex package
 install_trex() {
   local TREX_URL=https://trex-tgn.cisco.com/trex/release
@@ -44,20 +57,7 @@ install_trex() {
   rm ${TREX_ARCHIVE_NAME}
 }
 
-# Setup hugepages in cmdline
-setup_hugepages() {
-  mkdir -p /mnt/huge
-  echo "hugetlbfs /mnt/huge hugetlbfs defaults,pagesize=1GB 0 0" >> /etc/fstab
-
-  grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=1"
-}
-
-# Enable unsafe noiommu mode
-set_unsafe_no_io_mmu_mode() {
-  echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf
-}
-
 disable_services
 setup_hugepages
-install_trex
 set_unsafe_no_io_mmu_mode
+install_trex


### PR DESCRIPTION
The traffic-gen's `customize-vm` script is the same as the one used by the VM-under-test, with an
additional step of TRex installation.

Reorder the file so the two scripts would be aligned.