### PR TITLE
Add commit based tags on pushed quay images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,4 +140,6 @@ build-traffic-gen-container-disk: build-traffic-gen-vm-image
 
 push-traffic-gen-container-disk:
 	$(CRI_BIN) push $(REG)/$(ORG)/$(TRAFFIC_GEN_CONTAINER_DISK_IMAGE_NAME):$(TRAFFIC_GEN_CONTAINER_DISK_IMAGE_TAG)
+	$(CRI_BIN) tag $(REG)/$(ORG)/$(TRAFFIC_GEN_CONTAINER_DISK_IMAGE_NAME):$(TRAFFIC_GEN_CONTAINER_DISK_IMAGE_TAG) $(REG)/$(ORG)/$(TRAFFIC_GEN_CONTAINER_DISK_IMAGE_NAME):$(CHECKUP_GIT_TAG)
+	$(CRI_BIN) push $(REG)/$(ORG)/$(TRAFFIC_GEN_CONTAINER_DISK_IMAGE_NAME):$(CHECKUP_GIT_TAG)
 .PHONY: push-traffic-gen-container-disk

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ build-vm-container-disk: build-vm-image
 
 push-vm-container-disk:
 	$(CRI_BIN) push $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(VM_CONTAINER_DISK_IMAGE_TAG)
+	$(CRI_BIN) tag $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(VM_CONTAINER_DISK_IMAGE_TAG) $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(CHECKUP_GIT_TAG)
+	$(CRI_BIN) push $(REG)/$(ORG)/$(VM_CONTAINER_DISK_IMAGE_NAME):$(CHECKUP_GIT_TAG)
 .PHONY: push-vm-container-disk
 
 build-traffic-gen-vm-image: build-vm-image-builder


### PR DESCRIPTION
Currently only the actual checkup image is pushed to quay on every PR merged.
This PR does so also to the vm-under-test and traffic-gen container-disk images.