### PR TITLE
Make container disk images mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ roleRef:
 
 ## Configuration
 
-| Key                                        | Description                                                            | Is Mandatory | Remarks                                                               |
-|--------------------------------------------|------------------------------------------------------------------------|--------------|-----------------------------------------------------------------------|
-| spec.timeout                               | How much time before the checkup will try to close itself              | True         |                                                                       |
-| spec.param.networkAttachmentDefinitionName | NetworkAttachmentDefinition name of the SR-IOV NICs connected          | True         | Assumed to be in the same namespace                                   |
-| spec.param.trafficGenContainerDiskImage    | Traffic generator's container disk image                               | False        | Defaults to `quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main` |
-| spec.param.trafficGenTargetNodeName        | Node Name on which the traffic generator VM will be scheduled to       | False        | Assumed to be configured to Nodes that allow DPDK traffic             |
-| spec.param.trafficGenPacketsPerSecond      | Amount of packets per second. format: <amount>[/k/m] k-kilo; m-million | False        | Defaults to 8m                                                        |
-| spec.param.vmUnderTestContainerDiskImage   | VM under test container disk image                                     | False        | Defaults to `quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main`          |
-| spec.param.vmUnderTestTargetNodeName       | Node Name on which the VM under test will be scheduled to              | False        | Assumed to be configured to Nodes that allow DPDK traffic             |
-| spec.param.testDuration                    | How much time will the traffic generator will run                      | False        | Defaults to 5 Minutes                                                 |
-| spec.param.portBandwidthGbps               | SR-IOV NIC max bandwidth                                               | False        | Defaults to 10Gbps                                                    |
-| spec.param.verbose                         | Increases checkup's log verbosity                                      | False        | "true" / "false". Defaults to "false"                                 |
+| Key                                        | Description                                                            | Is Mandatory | Remarks                                                      |
+|--------------------------------------------|------------------------------------------------------------------------|--------------|--------------------------------------------------------------|
+| spec.timeout                               | How much time before the checkup will try to close itself              | True         |                                                              |
+| spec.param.networkAttachmentDefinitionName | NetworkAttachmentDefinition name of the SR-IOV NICs connected          | True         | Assumed to be in the same namespace                          |
+| spec.param.trafficGenContainerDiskImage    | Traffic generator's container disk image                               | True         |                                                              |
+| spec.param.trafficGenTargetNodeName        | Node Name on which the traffic generator VM will be scheduled to       | False        | Assumed to be configured to Nodes that allow DPDK traffic    |
+| spec.param.trafficGenPacketsPerSecond      | Amount of packets per second. format: <amount>[/k/m] k-kilo; m-million | False        | Defaults to 8m                                               |
+| spec.param.vmUnderTestContainerDiskImage   | VM under test container disk image                                     | False        | Defaults to `quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main` |
+| spec.param.vmUnderTestTargetNodeName       | Node Name on which the VM under test will be scheduled to              | False        | Assumed to be configured to Nodes that allow DPDK traffic    |
+| spec.param.testDuration                    | How much time will the traffic generator will run                      | False        | Defaults to 5 Minutes                                        |
+| spec.param.portBandwidthGbps               | SR-IOV NIC max bandwidth                                               | False        | Defaults to 10Gbps                                           |
+| spec.param.verbose                         | Increases checkup's log verbosity                                      | False        | "true" / "false". Defaults to "false"                        |
 
 ### Example
 
@@ -88,6 +88,7 @@ metadata:
 data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network-name>
+  spec.param.trafficGenContainerDiskImage: quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main
 ```
 
 ## Execution

--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ roleRef:
 
 ## Configuration
 
-| Key                                        | Description                                                            | Is Mandatory | Remarks                                                      |
-|--------------------------------------------|------------------------------------------------------------------------|--------------|--------------------------------------------------------------|
-| spec.timeout                               | How much time before the checkup will try to close itself              | True         |                                                              |
-| spec.param.networkAttachmentDefinitionName | NetworkAttachmentDefinition name of the SR-IOV NICs connected          | True         | Assumed to be in the same namespace                          |
-| spec.param.trafficGenContainerDiskImage    | Traffic generator's container disk image                               | True         |                                                              |
-| spec.param.trafficGenTargetNodeName        | Node Name on which the traffic generator VM will be scheduled to       | False        | Assumed to be configured to Nodes that allow DPDK traffic    |
-| spec.param.trafficGenPacketsPerSecond      | Amount of packets per second. format: <amount>[/k/m] k-kilo; m-million | False        | Defaults to 8m                                               |
-| spec.param.vmUnderTestContainerDiskImage   | VM under test container disk image                                     | False        | Defaults to `quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main` |
-| spec.param.vmUnderTestTargetNodeName       | Node Name on which the VM under test will be scheduled to              | False        | Assumed to be configured to Nodes that allow DPDK traffic    |
-| spec.param.testDuration                    | How much time will the traffic generator will run                      | False        | Defaults to 5 Minutes                                        |
-| spec.param.portBandwidthGbps               | SR-IOV NIC max bandwidth                                               | False        | Defaults to 10Gbps                                           |
-| spec.param.verbose                         | Increases checkup's log verbosity                                      | False        | "true" / "false". Defaults to "false"                        |
+| Key                                        | Description                                                            | Is Mandatory | Remarks                                                   |
+|--------------------------------------------|------------------------------------------------------------------------|--------------|-----------------------------------------------------------|
+| spec.timeout                               | How much time before the checkup will try to close itself              | True         |                                                           |
+| spec.param.networkAttachmentDefinitionName | NetworkAttachmentDefinition name of the SR-IOV NICs connected          | True         | Assumed to be in the same namespace                       |
+| spec.param.trafficGenContainerDiskImage    | Traffic generator's container disk image                               | True         |                                                           |
+| spec.param.trafficGenTargetNodeName        | Node Name on which the traffic generator VM will be scheduled to       | False        | Assumed to be configured to Nodes that allow DPDK traffic |
+| spec.param.trafficGenPacketsPerSecond      | Amount of packets per second. format: <amount>[/k/m] k-kilo; m-million | False        | Defaults to 8m                                            |
+| spec.param.vmUnderTestContainerDiskImage   | VM under test container disk image                                     | True         |                                                           |
+| spec.param.vmUnderTestTargetNodeName       | Node Name on which the VM under test will be scheduled to              | False        | Assumed to be configured to Nodes that allow DPDK traffic |
+| spec.param.testDuration                    | How much time will the traffic generator will run                      | False        | Defaults to 5 Minutes                                     |
+| spec.param.portBandwidthGbps               | SR-IOV NIC max bandwidth                                               | False        | Defaults to 10Gbps                                        |
+| spec.param.verbose                         | Increases checkup's log verbosity                                      | False        | "true" / "false". Defaults to "false"                     |
 
 ### Example
 
@@ -89,6 +89,7 @@ data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network-name>
   spec.param.trafficGenContainerDiskImage: quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main
+  spec.param.vmUnderTestContainerDiskImage: quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main
 ```
 
 ## Execution

--- a/pkg/internal/config/config.go
+++ b/pkg/internal/config/config.go
@@ -43,11 +43,10 @@ const (
 )
 
 const (
-	TrafficGenDefaultPacketsPerSecond    = "8m"
-	VMUnderTestDefaultContainerDiskImage = "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main"
-	TestDurationDefault                  = 5 * time.Minute
-	PortBandwidthGbpsDefault             = 10
-	VerboseDefault                       = false
+	TrafficGenDefaultPacketsPerSecond = "8m"
+	TestDurationDefault               = 5 * time.Minute
+	PortBandwidthGbpsDefault          = 10
+	VerboseDefault                    = false
 
 	TrafficGenMACAddressPrefixOctet  = 0x50
 	VMUnderTestMACAddressPrefixOctet = 0x60
@@ -72,6 +71,7 @@ var (
 	ErrInvalidTrafficGenContainerDiskImage    = errors.New("invalid Traffic Generator container disk image")
 	ErrIllegalTargetNodeNamesCombination      = errors.New("illegal Traffic Generator and VM under test target node names combination")
 	ErrInvalidTrafficGenPacketsPerSecond      = errors.New("invalid Traffic Generator Packets Per Second")
+	ErrInvalidVMUnderTestContainerDiskImage   = errors.New("invalid VM Under test container disk image")
 	ErrInvalidTestDuration                    = errors.New("invalid Test Duration")
 	ErrInvalidPortBandwidthGbps               = errors.New("invalid Port Bandwidth [Gbps]")
 	ErrInvalidVerbose                         = errors.New("invalid Verbose value [true|false]")
@@ -125,7 +125,7 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		TrafficGenPacketsPerSecond:      TrafficGenDefaultPacketsPerSecond,
 		TrafficGenEastMacAddress:        trafficGenEastMacAddress,
 		TrafficGenWestMacAddress:        trafficGenWestMacAddress,
-		VMUnderTestContainerDiskImage:   VMUnderTestDefaultContainerDiskImage,
+		VMUnderTestContainerDiskImage:   baseConfig.Params[VMUnderTestContainerDiskImageParamName],
 		VMUnderTestTargetNodeName:       baseConfig.Params[VMUnderTestTargetNodeNameParamName],
 		VMUnderTestEastMacAddress:       vmUnderTestEastMACAddress,
 		VMUnderTestWestMacAddress:       vmUnderTestWestMacAddress,
@@ -140,6 +140,10 @@ func New(baseConfig kconfig.Config) (Config, error) {
 
 	if newConfig.TrafficGenContainerDiskImage == "" {
 		return Config{}, ErrInvalidTrafficGenContainerDiskImage
+	}
+
+	if newConfig.VMUnderTestContainerDiskImage == "" {
+		return Config{}, ErrInvalidVMUnderTestContainerDiskImage
 	}
 
 	if newConfig.TrafficGenTargetNodeName == "" && newConfig.VMUnderTestTargetNodeName != "" ||
@@ -158,10 +162,6 @@ func setOptionalParams(baseConfig kconfig.Config, newConfig Config) (Config, err
 		if err != nil {
 			return Config{}, ErrInvalidTrafficGenPacketsPerSecond
 		}
-	}
-
-	if rawVal := baseConfig.Params[VMUnderTestContainerDiskImageParamName]; rawVal != "" {
-		newConfig.VMUnderTestContainerDiskImage = rawVal
 	}
 
 	if rawVal := baseConfig.Params[TestDurationParamName]; rawVal != "" {

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -52,6 +52,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		Params: map[string]string{
 			config.NetworkAttachmentDefinitionNameParamName: networkAttachmentDefinitionName,
 			config.TrafficGenContainerDiskImageParamName:    testTrafficGenContainerDiskImage,
+			config.VMUnderTestContainerDiskImageParamName:   testVMUnderTestContainerDiskImage,
 		},
 	}
 
@@ -71,7 +72,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		TrafficGenPacketsPerSecond:      config.TrafficGenDefaultPacketsPerSecond,
 		TrafficGenEastMacAddress:        actualConfig.TrafficGenEastMacAddress,
 		TrafficGenWestMacAddress:        actualConfig.TrafficGenWestMacAddress,
-		VMUnderTestContainerDiskImage:   config.VMUnderTestDefaultContainerDiskImage,
+		VMUnderTestContainerDiskImage:   testVMUnderTestContainerDiskImage,
 		VMUnderTestEastMacAddress:       actualConfig.VMUnderTestEastMacAddress,
 		VMUnderTestWestMacAddress:       actualConfig.VMUnderTestWestMacAddress,
 		TestDuration:                    config.TestDurationDefault,
@@ -168,6 +169,12 @@ func TestNewShouldFailWhen(t *testing.T) {
 			key:            config.TrafficGenContainerDiskImageParamName,
 			faultyKeyValue: "",
 			expectedError:  config.ErrInvalidTrafficGenContainerDiskImage,
+		},
+		{
+			description:    "VMUnderTestContainerDiskImage is invalid",
+			key:            config.VMUnderTestContainerDiskImageParamName,
+			faultyKeyValue: "",
+			expectedError:  config.ErrInvalidVMUnderTestContainerDiskImage,
 		},
 		{
 			description:    "trafficGenTargetNodeName is missing and vmUnderTestTargetNodeName is set",

--- a/pkg/internal/config/config_test.go
+++ b/pkg/internal/config/config_test.go
@@ -51,6 +51,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		PodUID:  testPodUID,
 		Params: map[string]string{
 			config.NetworkAttachmentDefinitionNameParamName: networkAttachmentDefinitionName,
+			config.TrafficGenContainerDiskImageParamName:    testTrafficGenContainerDiskImage,
 		},
 	}
 
@@ -66,7 +67,7 @@ func TestNewShouldApplyDefaultsWhenOptionalFieldsAreMissing(t *testing.T) {
 		PodName:                         testPodName,
 		PodUID:                          testPodUID,
 		NetworkAttachmentDefinitionName: networkAttachmentDefinitionName,
-		TrafficGenContainerDiskImage:    config.TrafficGenDefaultContainerDiskImage,
+		TrafficGenContainerDiskImage:    testTrafficGenContainerDiskImage,
 		TrafficGenPacketsPerSecond:      config.TrafficGenDefaultPacketsPerSecond,
 		TrafficGenEastMacAddress:        actualConfig.TrafficGenEastMacAddress,
 		TrafficGenWestMacAddress:        actualConfig.TrafficGenWestMacAddress,
@@ -161,6 +162,12 @@ func TestNewShouldFailWhen(t *testing.T) {
 			key:            config.NetworkAttachmentDefinitionNameParamName,
 			faultyKeyValue: "",
 			expectedError:  config.ErrInvalidNetworkAttachmentDefinitionName,
+		},
+		{
+			description:    "TrafficGenContainerDiskImage is invalid",
+			key:            config.TrafficGenContainerDiskImageParamName,
+			faultyKeyValue: "",
+			expectedError:  config.ErrInvalidTrafficGenContainerDiskImage,
 		},
 		{
 			description:    "trafficGenTargetNodeName is missing and vmUnderTestTargetNodeName is set",


### PR DESCRIPTION
Currently, trafficGenContainerDiskImage defaults to:
`quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main`.

and vmUnderTestContainerDiskImage defaults to:
`quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main`.

This may lead to unexpected behavior when using an older checkup version in combination with the latest container disk images (tagged as `main`).

Make the fields mandatory in order for the user to specify them explicitly.