### PR TITLE
Bump container disk images to CentOS stream 9

### DIFF
--- a/pkg/internal/checkup/executor/console/login.go
+++ b/pkg/internal/checkup/executor/console/login.go
@@ -106,7 +106,7 @@ func (e Expecter) LoginToCentOSAsRoot(password string) error {
 
 func configureConsole(expecter expect.Expecter) error {
 	batch := []expect.Batcher{
-		&expect.BSnd{S: "stty cols 500 rows 500\n"},
+		&expect.BSnd{S: "stty cols 160 rows 50\n"},
 		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: RetValue("0")},

--- a/vms/traffic-gen/scripts/build-vm-image
+++ b/vms/traffic-gen/scripts/build-vm-image
@@ -19,7 +19,7 @@
 
 export LIBGUESTFS_BACKEND=direct
 
-virt-builder centosstream-8 \
+virt-builder centosstream-9 \
   --format qcow2 \
   --root-password password:redhat \
   --install cloud-init,driverctl,tuned-profiles-cpu-partitioning,tar,python3,pciutils \

--- a/vms/traffic-gen/scripts/customize-vm
+++ b/vms/traffic-gen/scripts/customize-vm
@@ -63,8 +63,13 @@ install_trex() {
   rm ${TREX_ARCHIVE_NAME}
 }
 
+disable_bracketed_paste() {
+  echo "set enable-bracketed-paste off" >> /root/.inputrc
+}
+
 disable_services
 setup_hugepages
 set_unsafe_no_io_mmu_mode
 enable_guest_exec
 install_trex
+disable_bracketed_paste

--- a/vms/vm-under-test/scripts/build-vm-image
+++ b/vms/vm-under-test/scripts/build-vm-image
@@ -19,7 +19,7 @@
 
 export LIBGUESTFS_BACKEND=direct
 
-virt-builder centosstream-8 \
+virt-builder centosstream-9 \
   --format qcow2 \
   --root-password password:redhat \
   --install cloud-init,dpdk,dpdk-tools,driverctl,tuned-profiles-cpu-partitioning \

--- a/vms/vm-under-test/scripts/customize-vm
+++ b/vms/vm-under-test/scripts/customize-vm
@@ -46,7 +46,12 @@ enable_guest_exec() {
   sed -i '/^BLACKLIST_RPC=/ { s/,\+/,/g; s/^,\|,$//g }' /etc/sysconfig/qemu-ga
 }
 
+disable_bracketed_paste() {
+  echo "set enable-bracketed-paste off" >> /root/.inputrc
+}
+
 disable_services
 setup_hugepages
 set_unsafe_no_io_mmu_mode
 enable_guest_exec
+disable_bracketed_paste


### PR DESCRIPTION
CentOS stream 8 had reached EOL [1] and it breaks our automation for building the container disk image due to [2].

Our console package does not correctly handle Bracketed-paste [3], disable it for now.

[1] https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/

[2] https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve

[3] https://en.wikipedia.org/wiki/Bracketed-paste