### PR TITLE
go.mod: Add patch version to the go directive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GO_IMAGE_TAG := 1.22.5
 BIN_DIR = $(CURDIR)/_output/bin
 CRI_BIN ?= $(shell hack/detect_cri.sh)
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
-LINTER_IMAGE_TAG := v1.50.1
+LINTER_IMAGE_TAG := v1.60.1
 GO_MOD_VERSION=$(shell hack/go-mod-version.sh)
 KUBECONFIG ?= $(HOME)/.kube/config
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiagnose/kubevirt-dpdk-checkup
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f


### PR DESCRIPTION
"1.22" is not a valid toolchain name.

[1] https://go.dev/doc/toolchain#name
[2] https://github.com/golang/go/issues/62278#issuecomment-1693538776