### PR TITLE
Makefile, vendor: Remove compat flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ BIN_DIR = $(CURDIR)/_output/bin
 CRI_BIN ?= $(shell hack/detect_cri.sh)
 LINTER_IMAGE_NAME := docker.io/golangci/golangci-lint
 LINTER_IMAGE_TAG := v1.60.1
-GO_MOD_VERSION=$(shell hack/go-mod-version.sh)
 KUBECONFIG ?= $(HOME)/.kube/config
 
 E2E_TEST_TIMEOUT ?= 1h
@@ -91,7 +90,7 @@ vendor:
 	$(CRI_BIN) run --rm \
 	           --volume $(CURDIR):$(CURDIR):Z \
 	           --workdir $(CURDIR) \
-	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go mod tidy -compat=$(GO_MOD_VERSION) && go mod vendor
+	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go mod tidy && go mod vendor
 .PHONY: vendor
 
 build-vm-image-builder:

--- a/hack/go-mod-version.sh
+++ b/hack/go-mod-version.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-grep ^go go.mod | awk '{print $2}'
-


### PR DESCRIPTION
This action seems to be redundant and aggressive.

[1] https://go.dev/ref/mod#go-mod-tidy
[2] https://go.dev/ref/mod