### PR TITLE
Add multi-arch support for kubevirt-dpdk-checkup builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build:
 	           --volume $(CURDIR)/_go-cache:/root/.cache/go-build:Z \
 	           --workdir $(CURDIR) \
 	           -e GOOS=linux \
-	           -e GOARCH=amd64 \
+	           -e GOARCH=$(shell go env GOARCH) \
 	           $(GO_IMAGE_NAME):$(GO_IMAGE_TAG) go build -v -o $(BIN_DIR)/$(CHECKUP_IMAGE_NAME) ./cmd/
 	$(CRI_BIN) build --build-arg BASE_IMAGE_TAG=$(CHECKUP_BASE_IMAGE_TAG) . -t $(REG)/$(ORG)/$(CHECKUP_IMAGE_NAME):$(CHECKUP_IMAGE_TAG)
 .PHONY: build


### PR DESCRIPTION
This PR enables build process to support various architectures (e.g., amd64, s390x) for kubevirt-dpdk-checkup.

Currently, the images `kubevirt-dpdk-checkup-traffic-gen, kubevirt-dpdk-checkup-vm` are supported only on the amd64. With changes from this PR, we are now able to build and push also on other platforms, intently s390x.